### PR TITLE
Add reboot support, exclude-from-upgrade-all flag, and dashboard polling improvements

### DIFF
--- a/client/components/systems/SystemForm.tsx
+++ b/client/components/systems/SystemForm.tsx
@@ -12,6 +12,7 @@ interface SystemFormData {
   keyPassphrase?: string;
   sudoPassword?: string;
   disabledPkgManagers?: string[];
+  excludeFromUpgradeAll?: boolean;
   sourceSystemId?: number;
 }
 
@@ -23,9 +24,10 @@ export function SystemForm({
   onCancel,
   loading = false,
 }: {
-  initial?: Partial<SystemFormData> & {
+  initial?: Omit<Partial<SystemFormData>, 'excludeFromUpgradeAll'> & {
     detectedPkgManagers?: string[] | null;
     disabledPkgManagers?: string[] | null;
+    excludeFromUpgradeAll?: number;
   };
   systemId?: number;
   sourceSystemId?: number;
@@ -49,6 +51,9 @@ export function SystemForm({
   );
   const [disabledManagers, setDisabledManagers] = useState<Set<string>>(
     new Set(initial?.disabledPkgManagers ?? [])
+  );
+  const [excludeFromUpgradeAll, setExcludeFromUpgradeAll] = useState(
+    initial?.excludeFromUpgradeAll === 1
   );
 
   const toggleManager = (manager: string) => {
@@ -82,6 +87,7 @@ export function SystemForm({
       keyPassphrase: keyPassphrase || undefined,
       sudoPassword: sudoPassword || undefined,
       disabledPkgManagers: disabledManagers.size > 0 ? [...disabledManagers] : undefined,
+      excludeFromUpgradeAll,
       sourceSystemId,
     });
   };
@@ -158,6 +164,17 @@ export function SystemForm({
         <input type="password" value={sudoPassword} onChange={(e) => setSudoPassword(e.target.value)} className={inputClass} placeholder={sourceSystemId ? "(from source system)" : initial ? "(unchanged — defaults to SSH password)" : "Defaults to SSH password"} />
         <p className="text-xs text-slate-400 mt-1">Only needed if the sudo password differs from the SSH password</p>
       </div>
+
+      <label className="flex items-center gap-2 text-sm cursor-pointer">
+        <input
+          type="checkbox"
+          checked={excludeFromUpgradeAll}
+          onChange={(e) => setExcludeFromUpgradeAll(e.target.checked)}
+          className="rounded"
+        />
+        <span>Exclude from Upgrade All</span>
+        <span className="text-xs text-slate-400">(skip this system during bulk upgrades)</span>
+      </label>
 
       {testResult && (
         <div className={`p-3 rounded-lg text-sm ${testResult.success ? "bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400" : "bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400"}`}>

--- a/client/context/UpgradeContext.tsx
+++ b/client/context/UpgradeContext.tsx
@@ -10,6 +10,7 @@ import { useUpgradeAll, useFullUpgradeAll, useUpgradePackage } from "../lib/upda
 interface UpgradeEntry {
   type: "all" | "full_all" | "package";
   packageName?: string;
+  addedAt: number;
 }
 
 interface UpgradeCallbacks {
@@ -27,6 +28,7 @@ interface UpgradeContextType {
     callbacks?: UpgradeCallbacks
   ) => void;
   isUpgrading: (systemId: number) => boolean;
+  removeUpgrading: (systemId: number) => void;
   upgradingCount: number;
 }
 
@@ -58,7 +60,7 @@ export function UpgradeProvider({ children }: { children: ReactNode }) {
 
   const upgradeAll = useCallback(
     (systemId: number, callbacks?: UpgradeCallbacks) => {
-      addUpgrading(systemId, { type: "all" });
+      addUpgrading(systemId, { type: "all", addedAt: Date.now() });
       upgradeAllMutation.mutate(systemId, {
         onSuccess: (data) => {
           removeUpgrading(systemId);
@@ -75,7 +77,7 @@ export function UpgradeProvider({ children }: { children: ReactNode }) {
 
   const fullUpgradeAll = useCallback(
     (systemId: number, callbacks?: UpgradeCallbacks) => {
-      addUpgrading(systemId, { type: "full_all" });
+      addUpgrading(systemId, { type: "full_all", addedAt: Date.now() });
       fullUpgradeAllMutation.mutate(systemId, {
         onSuccess: (data) => {
           removeUpgrading(systemId);
@@ -92,7 +94,7 @@ export function UpgradeProvider({ children }: { children: ReactNode }) {
 
   const upgradePackage = useCallback(
     (systemId: number, packageName: string, callbacks?: UpgradeCallbacks) => {
-      addUpgrading(systemId, { type: "package", packageName });
+      addUpgrading(systemId, { type: "package", packageName, addedAt: Date.now() });
       upgradePackageMutation.mutate(
         { systemId, packageName },
         {
@@ -123,6 +125,7 @@ export function UpgradeProvider({ children }: { children: ReactNode }) {
         fullUpgradeAll,
         upgradePackage,
         isUpgrading,
+        removeUpgrading,
         upgradingCount: upgradingSystems.size,
       }}
     >

--- a/client/lib/dashboard.ts
+++ b/client/lib/dashboard.ts
@@ -11,24 +11,27 @@ export interface DashboardStats {
   needsReboot: number;
 }
 
-export function useDashboardStats() {
+export function useDashboardStats(hasActiveOps?: boolean) {
   return useQuery({
     queryKey: ["dashboard", "stats"],
     queryFn: () =>
       apiFetch<{ stats: DashboardStats }>("/dashboard/stats").then(
         (r) => r.stats
       ),
-    refetchInterval: 30_000,
+    refetchInterval: hasActiveOps ? 3000 : 30_000,
   });
 }
 
-export function useDashboardSystems() {
+export function useDashboardSystems(hasClientActiveOps?: boolean) {
   return useQuery({
     queryKey: ["dashboard", "systems"],
     queryFn: () =>
       apiFetch<{ systems: System[] }>("/dashboard/systems").then(
         (r) => r.systems
       ),
-    refetchInterval: 30_000,
+    refetchInterval: (query) => {
+      const hasServerActiveOps = query.state.data?.some((s) => s.activeOperation);
+      return (hasServerActiveOps || hasClientActiveOps) ? 3000 : 30_000;
+    },
   });
 }

--- a/client/pages/SystemsList.tsx
+++ b/client/pages/SystemsList.tsx
@@ -237,6 +237,7 @@ export default function SystemsList() {
             username: duplicateSource.username,
             detectedPkgManagers: duplicateSource.detectedPkgManagers ?? undefined,
             disabledPkgManagers: duplicateSource.disabledPkgManagers ?? undefined,
+            excludeFromUpgradeAll: duplicateSource.excludeFromUpgradeAll,
           } : undefined}
           sourceSystemId={duplicateSource?.id}
           onSubmit={handleCreate}
@@ -257,6 +258,7 @@ export default function SystemsList() {
               username: editSystem.username,
               detectedPkgManagers: editSystem.detectedPkgManagers ?? undefined,
               disabledPkgManagers: editSystem.disabledPkgManagers ?? undefined,
+              excludeFromUpgradeAll: editSystem.excludeFromUpgradeAll,
             }}
             systemId={editSystem.id}
             onSubmit={handleUpdate}

--- a/docker/test-systems/snap-setup.sh
+++ b/docker/test-systems/snap-setup.sh
@@ -10,8 +10,11 @@ for pkg in hello-world jq yq micro btop tree httpie certbot lolcat go; do
   esac
 done
 
-# Hold auto-refresh so snaps stay at the installed version
-snap refresh --hold
+# Disable the automatic refresh timer so snaps stay at whatever revision we
+# install.  Using "snap refresh --hold" would also hide them from
+# "snap refresh --list", so we stop the timer instead.
+systemctl stop snapd.refresh.timer 2>/dev/null || true
+systemctl disable snapd.refresh.timer 2>/dev/null || true
 
 # Downgrade non-classic snaps to their previous store revision so that
 # "snap refresh --list" always reports available updates for testing.

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -215,6 +215,13 @@ export function initDatabase(dbPath: string): BunSQLiteDatabase<typeof schema> {
     // Column already exists
   }
 
+  // Migration: add exclude from upgrade-all flag
+  try {
+    _db.run(sql`ALTER TABLE systems ADD COLUMN exclude_from_upgrade_all INTEGER NOT NULL DEFAULT 0`);
+  } catch {
+    // Column already exists
+  }
+
   // Migration: strip ntfyPriority from ntfy notification configs (priority is now automatic)
   _db.run(sql`UPDATE notifications SET config = json_remove(config, '$.ntfyPriority')
     WHERE type = 'ntfy' AND json_extract(config, '$.ntfyPriority') IS NOT NULL`);

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -55,6 +55,9 @@ export const systems = sqliteTable(
     cpuCores: text("cpu_cores"),
     memory: text("memory"),
     disk: text("disk"),
+    excludeFromUpgradeAll: integer("exclude_from_upgrade_all")
+      .notNull()
+      .default(0),
     needsReboot: integer("needs_reboot").notNull().default(0),
     systemInfoUpdatedAt: text("system_info_updated_at"),
     isReachable: integer("is_reachable").notNull().default(0),

--- a/server/routes/dashboard.ts
+++ b/server/routes/dashboard.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import * as systemService from "../services/system-service";
 import * as cacheService from "../services/cache-service";
+import * as updateService from "../services/update-service";
 
 const dashboard = new Hono();
 
@@ -11,6 +12,7 @@ dashboard.get("/stats", (c) => {
     ...s,
     cacheAge: cacheService.getCacheAge(s.id),
     isStale: cacheService.isCacheStale(s.id),
+    activeOperation: updateService.getActiveOperation(s.id),
   }));
 
   const total = systemsWithMeta.length;
@@ -43,6 +45,7 @@ dashboard.get("/systems", (c) => {
     ...s,
     cacheAge: cacheService.getCacheAge(s.id),
     isStale: cacheService.isCacheStale(s.id),
+    activeOperation: updateService.getActiveOperation(s.id),
   }));
 
   return c.json({ systems: systemsWithMeta });

--- a/server/routes/systems.ts
+++ b/server/routes/systems.ts
@@ -73,6 +73,7 @@ systems.post("/", async (c) => {
     keyPassphrase: body.keyPassphrase || undefined,
     sudoPassword: body.sudoPassword || undefined,
     disabledPkgManagers: body.disabledPkgManagers || undefined,
+    excludeFromUpgradeAll: body.excludeFromUpgradeAll,
     sourceSystemId: body.sourceSystemId || undefined,
   });
 
@@ -98,9 +99,17 @@ systems.put("/:id", async (c) => {
     keyPassphrase: body.keyPassphrase || undefined,
     sudoPassword: body.sudoPassword || undefined,
     disabledPkgManagers: body.disabledPkgManagers || undefined,
+    excludeFromUpgradeAll: body.excludeFromUpgradeAll,
   });
 
   return c.json({ status: "ok" });
+});
+
+// Reboot system
+systems.post("/:id/reboot", async (c) => {
+  const id = parseInt(c.req.param("id"), 10);
+  const result = await updateService.rebootSystem(id);
+  return c.json(result, result.success ? 200 : 500);
 });
 
 // Delete system

--- a/server/services/cache-service.ts
+++ b/server/services/cache-service.ts
@@ -86,6 +86,15 @@ export function invalidateCache(systemId?: number): void {
   }
 }
 
+export function getAllSystemIds(): number[] {
+  const db = getDb();
+  return db
+    .select({ id: systems.id })
+    .from(systems)
+    .all()
+    .map((r) => r.id);
+}
+
 export function getStaleSystemIds(): number[] {
   const cacheHours = getCacheDurationHours();
   const threshold = new Date(
@@ -93,12 +102,7 @@ export function getStaleSystemIds(): number[] {
   ).toISOString().replace("T", " ").slice(0, 19);
 
   const db = getDb();
-
-  const allIds = db
-    .select({ id: systems.id })
-    .from(systems)
-    .all()
-    .map((r) => r.id);
+  const allIds = getAllSystemIds();
 
   const freshRows = db
     .select({ systemId: updateCache.systemId })

--- a/server/services/system-service.ts
+++ b/server/services/system-service.ts
@@ -32,6 +32,7 @@ export function createSystem(data: {
   keyPassphrase?: string;
   sudoPassword?: string;
   disabledPkgManagers?: string[];
+  excludeFromUpgradeAll?: boolean;
   sourceSystemId?: number;
 }): number {
   const encryptor = getEncryptor();
@@ -79,6 +80,9 @@ export function createSystem(data: {
   if (data.disabledPkgManagers) {
     values.disabledPkgManagers = JSON.stringify(data.disabledPkgManagers);
   }
+  if (data.excludeFromUpgradeAll !== undefined) {
+    values.excludeFromUpgradeAll = data.excludeFromUpgradeAll ? 1 : 0;
+  }
 
   const result = db.insert(systems).values(values as typeof systems.$inferInsert).returning({ id: systems.id }).get();
   return result.id;
@@ -97,6 +101,7 @@ export function updateSystem(
     keyPassphrase?: string;
     sudoPassword?: string;
     disabledPkgManagers?: string[];
+    excludeFromUpgradeAll?: boolean;
   }
 ): void {
   const encryptor = getEncryptor();
@@ -124,6 +129,9 @@ export function updateSystem(
   }
   if (data.disabledPkgManagers !== undefined) {
     values.disabledPkgManagers = JSON.stringify(data.disabledPkgManagers);
+  }
+  if (data.excludeFromUpgradeAll !== undefined) {
+    values.excludeFromUpgradeAll = data.excludeFromUpgradeAll ? 1 : 0;
   }
 
   db.update(systems)

--- a/server/ssh/system-info.ts
+++ b/server/ssh/system-info.ts
@@ -13,7 +13,7 @@ export const SYSTEM_INFO_CMD =
   'if [ -f /var/run/reboot-required ]; then echo "REBOOT_REQUIRED"; ' +
   'elif command -v needs-restarting >/dev/null 2>&1; then needs-restarting -r >/dev/null 2>&1; [ $? -eq 1 ] && echo "REBOOT_REQUIRED" || echo "NO_REBOOT"; ' +
   'else RUNNING=$(uname -r); LATEST=$(ls -1v /lib/modules/ 2>/dev/null | tail -1); ' +
-  '[ -n "$LATEST" ] && [ "$RUNNING" != "$LATEST" ] && echo "REBOOT_REQUIRED" || echo "NO_REBOOT"; fi';
+  '[ -n "$LATEST" ] && [ -d "/lib/modules/$RUNNING" ] && [ "$RUNNING" != "$LATEST" ] && echo "REBOOT_REQUIRED" || echo "NO_REBOOT"; fi';
 
 export interface SystemInfo {
   osName: string;


### PR DESCRIPTION
- Add per-system "Exclude from Upgrade All" setting with detailed upgrade confirmation modal
- Add remote reboot via SSH with confirmation dialog and active operation tracking
- Sync client-side upgrade state with server activeOperation to fix stale entries during concurrent upgrades
- Poll dashboard and system lists at 3s during active operations, 30s otherwise
- Show checking/upgrading state on dashboard system cards
- Refresh all systems on scheduler startup instead of only stale ones
- Add "test" mode to run.sh for Docker test container workflow
- Fix snap refresh timer handling and reboot detection for missing kernel module dirs