### PR TITLE
Harden security: rate limiting, input validation, rolling sessions, and per-instance encryption salt

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -15,6 +15,15 @@ export { websocket };
 export function createApp() {
   const app = new Hono();
 
+  // Security headers
+  app.use("*", async (c, next) => {
+    await next();
+    c.header("X-Content-Type-Options", "nosniff");
+    c.header("X-Frame-Options", "DENY");
+    c.header("Referrer-Policy", "strict-origin-when-cross-origin");
+    c.header("X-Permitted-Cross-Domain-Policies", "none");
+  });
+
   // CORS for development (Vite dev server on different port)
   if (process.env.NODE_ENV !== "production") {
     app.use(

--- a/server/auth/oidc.ts
+++ b/server/auth/oidc.ts
@@ -53,15 +53,16 @@ export function getAuthorizationUrl(state: string, nonce: string, redirectUri: s
 
 export async function handleCallback(
   currentUrl: URL,
-  expectedNonce?: string
+  expectedNonce?: string,
+  expectedState?: string,
 ): Promise<{ username: string; email?: string } | null> {
   if (!_config) throw new Error("OIDC not configured");
 
   try {
     const tokens = await client.authorizationCodeGrant(_config, currentUrl, {
       expectedNonce,
-      expectedState: client.skipStateCheck,
-    } as Parameters<typeof client.authorizationCodeGrant>[2]);
+      expectedState,
+    });
 
     const claims = tokens.claims();
     if (!claims) return null;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,25 +1,29 @@
-import { mkdirSync } from "fs";
+import { mkdirSync, chmodSync } from "fs";
 import { dirname } from "path";
 import { eq } from "drizzle-orm";
-import { config } from "./config";
+import { config, getEncryptionSalt } from "./config";
 import { initDatabase, closeDatabase, getDb } from "./db";
-import { settings } from "./db/schema";
-import { initEncryptor, getEncryptor } from "./security";
+import { settings, systems, notifications } from "./db/schema";
+import { CredentialEncryptor, isPassphraseKey, initEncryptor, getEncryptor } from "./security";
 import { initSSHManager } from "./ssh/connection";
 import { initSession } from "./auth/session";
 import { configureOidc } from "./auth/oidc";
 import * as scheduler from "./services/scheduler";
 import { createApp, websocket } from "./app";
 
-// Ensure data directory exists
+// Ensure data directory exists with restrictive permissions
 mkdirSync(dirname(config.dbPath), { recursive: true });
+try { chmodSync(dirname(config.dbPath), 0o700); } catch { /* Windows */ }
 
 // Initialize core systems
 console.log("Initializing database...");
 const db = initDatabase(config.dbPath);
+try { chmodSync(config.dbPath, 0o600); } catch { /* Windows */ }
 
 console.log("Initializing encryption...");
-initEncryptor(config.encryptionKey);
+const salt = getEncryptionSalt(config.dbPath, config.encryptionKey);
+migrateEncryptionSalt(config.encryptionKey, salt);
+initEncryptor(config.encryptionKey, salt);
 
 console.log("Initializing session management...");
 initSession(config.secretKey);
@@ -83,3 +87,126 @@ process.on("SIGTERM", () => {
   server.stop();
   process.exit(0);
 });
+
+// --- Encryption salt migration ---
+// Re-encrypts all data from the legacy hardcoded salt to the per-instance salt.
+// Only runs for passphrase-derived keys when a new salt file was just created.
+function migrateEncryptionSalt(rawKey: string, newSalt: Buffer | null): void {
+  if (!newSalt || !isPassphraseKey(rawKey)) return;
+
+  // Check if there's any encrypted data that was encrypted with the old salt.
+  // If the DB is empty (fresh install), the new salt was just written and there's nothing to migrate.
+  const dbInstance = getDb();
+  const anySystem = dbInstance.select({ id: systems.id }).from(systems).limit(1).get();
+  const anyEncryptedSetting = dbInstance
+    .select()
+    .from(settings)
+    .where(eq(settings.key, "oidc_client_secret"))
+    .get();
+
+  const hasEncryptedData =
+    anySystem ||
+    (anyEncryptedSetting?.value && anyEncryptedSetting.value.length > 0);
+
+  if (!hasEncryptedData) return;
+
+  // Try to decrypt with OLD (legacy) encryptor to see if migration is needed
+  const oldEncryptor = new CredentialEncryptor(rawKey); // uses LEGACY_SALT
+  const newEncryptor = new CredentialEncryptor(rawKey, newSalt);
+
+  console.log("Migrating encrypted data to per-instance salt...");
+
+  // Helper: re-encrypt a single value
+  function reEncrypt(value: string | null): string | null {
+    if (!value) return null;
+    try {
+      const plaintext = oldEncryptor.decrypt(value);
+      return newEncryptor.encrypt(plaintext);
+    } catch {
+      // Already migrated or invalid — leave as-is
+      return value;
+    }
+  }
+
+  // Migrate systems table
+  const allSystems = dbInstance.select().from(systems).all();
+  for (const sys of allSystems) {
+    const updates: Record<string, string | null> = {};
+    let changed = false;
+
+    for (const col of [
+      "encryptedPassword",
+      "encryptedPrivateKey",
+      "encryptedKeyPassphrase",
+      "encryptedSudoPassword",
+    ] as const) {
+      const val = sys[col];
+      if (val) {
+        const reEncrypted = reEncrypt(val);
+        if (reEncrypted !== val) {
+          updates[col] = reEncrypted;
+          changed = true;
+        }
+      }
+    }
+
+    if (changed) {
+      dbInstance
+        .update(systems)
+        .set(updates as any)
+        .where(eq(systems.id, sys.id))
+        .run();
+    }
+  }
+
+  // Migrate oidc_client_secret in settings
+  if (anyEncryptedSetting?.value) {
+    const reEncrypted = reEncrypt(anyEncryptedSetting.value);
+    if (reEncrypted !== anyEncryptedSetting.value) {
+      dbInstance
+        .update(settings)
+        .set({ value: reEncrypted! })
+        .where(eq(settings.key, "oidc_client_secret"))
+        .run();
+    }
+  }
+
+  // Migrate sensitive fields in notifications config
+  const SENSITIVE_KEYS: Record<string, string[]> = {
+    email: ["smtpPassword"],
+    ntfy: ["ntfyToken"],
+  };
+
+  const allNotifications = dbInstance.select().from(notifications).all();
+  for (const notif of allNotifications) {
+    const sensitiveFields = SENSITIVE_KEYS[notif.type] || [];
+    if (sensitiveFields.length === 0) continue;
+
+    try {
+      const config = JSON.parse(notif.config);
+      let changed = false;
+
+      for (const field of sensitiveFields) {
+        if (config[field] && config[field] !== "(stored)") {
+          const reEncrypted = reEncrypt(config[field]);
+          if (reEncrypted !== config[field]) {
+            config[field] = reEncrypted;
+            changed = true;
+          }
+        }
+      }
+
+      if (changed) {
+        dbInstance
+          .update(notifications)
+          .set({ config: JSON.stringify(config) })
+          .where(eq(notifications.id, notif.id))
+          .run();
+      }
+    } catch {
+      // Invalid JSON config — skip
+    }
+  }
+
+  console.log("Encryption migration complete.");
+}

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -1,6 +1,6 @@
 import { createMiddleware } from "hono/factory";
 import { eq, count } from "drizzle-orm";
-import { getSession, type SessionData } from "../auth/session";
+import { getSession, refreshSessionIfNeeded, type SessionData } from "../auth/session";
 import { getDb } from "../db";
 import { users } from "../db/schema";
 
@@ -43,6 +43,10 @@ export const authMiddleware = createMiddleware<AuthEnv>(async (c, next) => {
     }
 
     c.set("user", session);
+
+    // Rolling session: refresh token if it's past the halfway point
+    await refreshSessionIfNeeded(c);
+
     return next();
   }
 

--- a/server/middleware/rate-limit.ts
+++ b/server/middleware/rate-limit.ts
@@ -1,0 +1,51 @@
+import { createMiddleware } from "hono/factory";
+
+interface RateLimitEntry {
+  timestamps: number[];
+}
+
+const store = new Map<string, RateLimitEntry>();
+
+// Clean up expired entries every 5 minutes
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of store) {
+    entry.timestamps = entry.timestamps.filter((t) => now - t < 120_000);
+    if (entry.timestamps.length === 0) store.delete(key);
+  }
+}, 300_000);
+
+/**
+ * Create a rate limiting middleware.
+ * @param maxRequests Maximum requests allowed in the window
+ * @param windowMs Time window in milliseconds
+ */
+export function rateLimit(maxRequests: number, windowMs: number) {
+  return createMiddleware(async (c, next) => {
+    const ip =
+      c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ||
+      c.req.header("x-real-ip") ||
+      "unknown";
+    const key = `${ip}:${c.req.path}`;
+    const now = Date.now();
+
+    let entry = store.get(key);
+    if (!entry) {
+      entry = { timestamps: [] };
+      store.set(key, entry);
+    }
+
+    // Remove timestamps outside the window
+    entry.timestamps = entry.timestamps.filter((t) => now - t < windowMs);
+
+    if (entry.timestamps.length >= maxRequests) {
+      const oldestInWindow = entry.timestamps[0];
+      const retryAfter = Math.ceil((oldestInWindow + windowMs - now) / 1000);
+      c.header("Retry-After", String(retryAfter));
+      return c.json({ error: "Too many requests" }, 429);
+    }
+
+    entry.timestamps.push(now);
+    return next();
+  });
+}

--- a/server/ssh/parsers/apt.ts
+++ b/server/ssh/parsers/apt.ts
@@ -1,5 +1,5 @@
 import type { PackageParser, ParsedUpdate } from "./types";
-import { sudo } from "./types";
+import { sudo, validatePackageName } from "./types";
 
 // Example: curl/jammy-updates 7.81.0-1ubuntu1.18 amd64 [upgradable from: 7.81.0-1ubuntu1.16]
 const PATTERN =
@@ -62,9 +62,10 @@ export const aptParser: PackageParser = {
   },
 
   getUpgradePackageCommand(pkg) {
+    const safePkg = validatePackageName(pkg);
     return (
       "export DEBIAN_FRONTEND=noninteractive; " +
-      sudo(`apt-get ${LOCK_WAIT} install --only-upgrade -y ${pkg}`) +
+      sudo(`apt-get ${LOCK_WAIT} install --only-upgrade -y ${safePkg}`) +
       " 2>&1"
     );
   },

--- a/server/ssh/parsers/dnf.ts
+++ b/server/ssh/parsers/dnf.ts
@@ -1,5 +1,5 @@
 import type { PackageParser, ParsedUpdate } from "./types";
-import { sudo } from "./types";
+import { sudo, validatePackageName } from "./types";
 
 // Example: curl.x86_64    7.76.1-26.el9_3.3    baseos
 const PATTERN = /^(\S+?)\.(\S+)\s+(\S+)\s+(\S+)/;
@@ -103,6 +103,7 @@ export const dnfParser: PackageParser = {
   },
 
   getUpgradePackageCommand(pkg) {
-    return sudo(`dnf upgrade -y ${pkg}`) + " 2>&1";
+    const safePkg = validatePackageName(pkg);
+    return sudo(`dnf upgrade -y ${safePkg}`) + " 2>&1";
   },
 };

--- a/server/ssh/parsers/flatpak.ts
+++ b/server/ssh/parsers/flatpak.ts
@@ -1,5 +1,5 @@
 import type { PackageParser, ParsedUpdate } from "./types";
-import { sudo } from "./types";
+import { sudo, validatePackageName } from "./types";
 
 const INSTALLED_MARKER = "===INSTALLED===";
 const UPDATES_MARKER = "===UPDATES===";
@@ -80,6 +80,7 @@ export const flatpakParser: PackageParser = {
   },
 
   getUpgradePackageCommand(pkg) {
-    return sudo(`flatpak update -y ${pkg}`) + " 2>&1";
+    const safePkg = validatePackageName(pkg);
+    return sudo(`flatpak update -y ${safePkg}`) + " 2>&1";
   },
 };

--- a/server/ssh/parsers/pacman.ts
+++ b/server/ssh/parsers/pacman.ts
@@ -1,5 +1,5 @@
 import type { PackageParser, ParsedUpdate } from "./types";
-import { sudo } from "./types";
+import { sudo, validatePackageName } from "./types";
 
 // Example: linux 6.7.4.arch1-1 -> 6.7.5.arch1-1
 const PATTERN = /^(\S+)\s+(\S+)\s+->\s+(\S+)/;
@@ -44,6 +44,7 @@ export const pacmanParser: PackageParser = {
   },
 
   getUpgradePackageCommand(pkg) {
-    return sudo(`pacman -S --noconfirm ${pkg}`) + " 2>&1";
+    const safePkg = validatePackageName(pkg);
+    return sudo(`pacman -S --noconfirm ${safePkg}`) + " 2>&1";
   },
 };

--- a/server/ssh/parsers/snap.ts
+++ b/server/ssh/parsers/snap.ts
@@ -1,5 +1,5 @@
 import type { PackageParser, ParsedUpdate } from "./types";
-import { sudo } from "./types";
+import { sudo, validatePackageName } from "./types";
 
 const INSTALLED_MARKER = "===INSTALLED===";
 const UPDATES_MARKER = "===UPDATES===";
@@ -75,6 +75,7 @@ export const snapParser: PackageParser = {
   },
 
   getUpgradePackageCommand(pkg) {
-    return sudo(`snap refresh ${pkg}`) + " 2>&1";
+    const safePkg = validatePackageName(pkg);
+    return sudo(`snap refresh ${safePkg}`) + " 2>&1";
   },
 };

--- a/server/ssh/parsers/types.ts
+++ b/server/ssh/parsers/types.ts
@@ -24,6 +24,20 @@ export interface PackageParser {
 }
 
 /**
+ * Validate a package name to prevent shell injection.
+ * Allows alphanumeric, dots, hyphens, underscores, plus, colon, tilde.
+ * Throws if the name contains shell metacharacters or is empty.
+ */
+const VALID_PKG_NAME = /^[a-zA-Z0-9][a-zA-Z0-9._+:~-]*$/;
+
+export function validatePackageName(pkg: string): string {
+  if (!pkg || !VALID_PKG_NAME.test(pkg)) {
+    throw new Error(`Invalid package name: ${pkg.slice(0, 80)}`);
+  }
+  return pkg;
+}
+
+/**
  * Wrap a command to use sudo if available, otherwise run directly.
  * Handles: root user, sudo available, no root/no sudo.
  */

--- a/server/ssh/parsers/yum.ts
+++ b/server/ssh/parsers/yum.ts
@@ -1,5 +1,5 @@
 import type { PackageParser } from "./types";
-import { sudo } from "./types";
+import { sudo, validatePackageName } from "./types";
 import { buildCheckCommand, dnfParser } from "./dnf";
 
 export const yumParser: PackageParser = {
@@ -24,6 +24,7 @@ export const yumParser: PackageParser = {
   },
 
   getUpgradePackageCommand(pkg) {
-    return sudo(`yum update -y ${pkg}`) + " 2>&1";
+    const safePkg = validatePackageName(pkg);
+    return sudo(`yum update -y ${safePkg}`) + " 2>&1";
   },
 };


### PR DESCRIPTION
- Add rate limiting on auth endpoints (login, setup, WebAuthn verify)
- Add timing-safe login with dummy hash to prevent username enumeration
- Add input validation for system fields (hostname, port, username) and password complexity
- Add package name validation to prevent shell injection in upgrade commands
- Switch to short-lived JWTs (1h) with rolling refresh via cookie, secure flag for HTTPS
- Add per-instance encryption salt for PBKDF2 key derivation with auto-migration from legacy salt
- Require LUDASH_ENCRYPTION_KEY env var (no longer optional)
- Validate OIDC state parameter and encrypt client secrets at rest
- Add security headers (X-Content-Type-Options, X-Frame-Options, Referrer-Policy)
- Set restrictive file permissions (0600/0700) on data directory and key files
- Use crypto.randomUUID() for job IDs instead of sequential counters
- Sanitize WebAuthn error messages to avoid leaking internals
- Update README with new features and security documentation
- Add tests for package name validation and per-instance salt encryption