### PR TITLE
fix: allow private/local NTFY server URLs for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ All endpoints require authentication unless noted. Responses are JSON.
 - **Session security:** HTTP-only, SameSite=Lax cookies with JWT (HS256)
 - **CSRF protection:** state-changing API requests require a per-session CSRF token header
 - **Input validation:** strict type, format, and range validation on all API inputs
-- **SSRF protection:** outbound notification URLs are validated against private/internal IP ranges
+- **Notification URL validation:** outbound notification URLs are validated for correct format (http/https); private/local targets are allowed since they are admin-configured
 - **Rate limiting:** auth endpoints are rate-limited (3 req/min for setup, 5 req/min for login and WebAuthn verify, 20 failed bearer attempts/min per IP)
 - **API token security:** only SHA-256 hashes stored, tokens blocked from management endpoints, CSRF skipped for stateless bearer requests
 - **Password-disable safeguard:** password login cannot be disabled unless a passkey or SSO is configured (enforced server-side)

--- a/server/services/notifications/ntfy.ts
+++ b/server/services/notifications/ntfy.ts
@@ -1,6 +1,5 @@
 import type { NotificationProvider, NotificationPayload, NotificationResult } from "./types";
 import { getEncryptor } from "../../security";
-import { isSafeOutboundUrl } from "../../request-security";
 
 function validateUrl(raw: string): string | null {
   try {
@@ -33,9 +32,6 @@ export const ntfyProvider: NotificationProvider = {
   },
 
   async send(payload: NotificationPayload, config: Record<string, string>): Promise<NotificationResult> {
-    // Re-validate URL at send time as defense-in-depth, including DNS/IP checks.
-    const outbound = await isSafeOutboundUrl(config.ntfyUrl);
-    if (!outbound.safe) return { success: false, error: outbound.reason };
 
     const baseUrl = config.ntfyUrl.replace(/\/+$/, "");
     const url = `${baseUrl}/${encodeURIComponent(config.ntfyTopic)}`;

--- a/tests/server/ntfy-security.test.ts
+++ b/tests/server/ntfy-security.test.ts
@@ -1,20 +1,44 @@
 import { describe, expect, test } from "bun:test";
 import { ntfyProvider } from "../../server/services/notifications/ntfy";
 
-describe("ntfy provider SSRF protection", () => {
-  test("blocks loopback/private targets at send time", async () => {
-    const result = await ntfyProvider.send(
-      {
-        title: "test",
-        body: "body",
-      },
-      {
-        ntfyUrl: "http://127.0.0.1",
-        ntfyTopic: "updates",
-      }
-    );
+describe("ntfy provider validation", () => {
+  test("rejects invalid URL format", () => {
+    const result = ntfyProvider.validateConfig({
+      ntfyUrl: "not-a-url",
+      ntfyTopic: "updates",
+    });
+    expect(result).toContain("Invalid URL");
+  });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("must not point");
+  test("rejects non-http(s) URL", () => {
+    const result = ntfyProvider.validateConfig({
+      ntfyUrl: "ftp://example.com",
+      ntfyTopic: "updates",
+    });
+    expect(result).toContain("http or https");
+  });
+
+  test("rejects invalid topic characters", () => {
+    const result = ntfyProvider.validateConfig({
+      ntfyUrl: "https://ntfy.sh",
+      ntfyTopic: "bad topic!",
+    });
+    expect(result).toContain("topic must only contain");
+  });
+
+  test("accepts valid config with private IP", () => {
+    const result = ntfyProvider.validateConfig({
+      ntfyUrl: "http://192.168.1.100",
+      ntfyTopic: "updates",
+    });
+    expect(result).toBeNull();
+  });
+
+  test("accepts valid config with public URL", () => {
+    const result = ntfyProvider.validateConfig({
+      ntfyUrl: "https://ntfy.sh",
+      ntfyTopic: "my-topic",
+    });
+    expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
Remove SSRF protection from ntfy provider since notification targets are admin-configured and self-hosted servers on local networks are a legitimate use case. Update tests and README accordingly.