### PR TITLE
Improve reboot-required detection and dismissal flow

### DIFF
--- a/client/lib/systems.ts
+++ b/client/lib/systems.ts
@@ -282,6 +282,19 @@ export function useRebootSystem() {
   });
 }
 
+export function useDismissNeedsReboot() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) =>
+      apiFetch<{ status: string }>(`/systems/${id}/dismiss-needs-reboot`, { method: "POST" }),
+    onSuccess: async (_data, id) => {
+      await qc.invalidateQueries({ queryKey: ["system", id] });
+      await qc.invalidateQueries({ queryKey: ["systems"] });
+      await qc.invalidateQueries({ queryKey: ["dashboard"] });
+    },
+  });
+}
+
 export function useTestConnection() {
   return useMutation({
     mutationFn: (data: {

--- a/client/pages/SystemDetail.tsx
+++ b/client/pages/SystemDetail.tsx
@@ -5,7 +5,7 @@ import { AgoLabel } from "../components/AgoLabel";
 import { Badge } from "../components/Badge";
 import { ConfirmDialog } from "../components/ConfirmDialog";
 import { useQueryClient } from "@tanstack/react-query";
-import { useSystem, useRebootSystem } from "../lib/systems";
+import { useSystem, useRebootSystem, useDismissNeedsReboot } from "../lib/systems";
 import { useCheckUpdates, useHideUpdate, useUnhideUpdate } from "../lib/updates";
 import { useToast } from "../context/ToastContext";
 import { useUpgrade } from "../context/UpgradeContext";
@@ -1100,10 +1100,12 @@ export default function SystemDetail() {
   const { upgradeAll, fullUpgradeAll, upgradePackages, isUpgrading } = useUpgrade();
   const { addToast } = useToast();
   const rebootSystem = useRebootSystem();
+  const dismissNeedsReboot = useDismissNeedsReboot();
   const [showUpgradeConfirm, setShowUpgradeConfirm] = useState(false);
   const [showUpgradeSelectedConfirm, setShowUpgradeSelectedConfirm] = useState(false);
   const [showFullUpgradeConfirm, setShowFullUpgradeConfirm] = useState(false);
   const [showRebootConfirm, setShowRebootConfirm] = useState(false);
+  const [showDismissNeedsRebootConfirm, setShowDismissNeedsRebootConfirm] = useState(false);
   const [pendingHideUpdate, setPendingHideUpdate] = useState<CachedUpdate | null>(null);
   const [selectedPackageNames, setSelectedPackageNames] = useState<string[]>([]);
   const [showUpgradeDropdown, setShowUpgradeDropdown] = useState(false);
@@ -1137,6 +1139,7 @@ export default function SystemDetail() {
   const checking = checkUpdates.isPending || activeOp?.type === "check";
   const upgrading = isUpgrading(systemId) || activeOp?.type === "upgrade_all" || activeOp?.type === "full_upgrade_all" || activeOp?.type === "upgrade_package";
   const rebooting = rebootSystem.isPending || activeOp?.type === "reboot";
+  const dismissingNeedsReboot = dismissNeedsReboot.isPending;
   const updatesSignature = data?.updates
     .map((update) => `${update.pkgManager}:${update.packageName}:${update.newVersion || ""}`)
     .join("|") ?? "";
@@ -1257,6 +1260,14 @@ export default function SystemDetail() {
     rebootSystem.mutate(systemId, {
       onSuccess: (d) =>
         addToast(d.success ? "Reboot command sent" : d.message, d.success ? "success" : "danger"),
+      onError: (err) => addToast(err.message, "danger"),
+    });
+  };
+
+  const handleDismissNeedsReboot = () => {
+    setShowDismissNeedsRebootConfirm(false);
+    dismissNeedsReboot.mutate(systemId, {
+      onSuccess: () => addToast("Reboot warning dismissed", "success"),
       onError: (err) => addToast(err.message, "danger"),
     });
   };
@@ -1494,8 +1505,8 @@ export default function SystemDetail() {
           <span className="text-amber-600 dark:text-amber-500 flex-1">A kernel update has been installed. Reboot this system to apply it.</span>
           <button
             onClick={() => setShowRebootConfirm(true)}
-            disabled={rebooting || upgrading || checking}
-            className="ml-auto px-3 py-1 text-xs font-medium rounded-lg bg-amber-600 hover:bg-amber-700 text-white transition-colors disabled:opacity-50 whitespace-nowrap shrink-0"
+            disabled={rebooting || upgrading || checking || dismissingNeedsReboot}
+            className="px-3 py-1 text-xs font-medium rounded-lg bg-amber-600 hover:bg-amber-700 text-white transition-colors disabled:opacity-50 whitespace-nowrap shrink-0"
           >
             {rebooting ? (
               <span className="flex items-center gap-1.5">
@@ -1503,6 +1514,18 @@ export default function SystemDetail() {
                 Rebooting...
               </span>
             ) : "Reboot"}
+          </button>
+          <button
+            onClick={() => setShowDismissNeedsRebootConfirm(true)}
+            disabled={dismissingNeedsReboot || rebooting || upgrading || checking}
+            className="px-3 py-1 text-xs font-medium rounded-lg border border-amber-300 dark:border-amber-700 bg-white/70 dark:bg-slate-900/30 text-amber-700 dark:text-amber-400 hover:bg-white dark:hover:bg-slate-900/50 transition-colors disabled:opacity-50 whitespace-nowrap shrink-0"
+          >
+            {dismissingNeedsReboot ? (
+              <span className="flex items-center gap-1.5">
+                <span className="spinner spinner-sm" />
+                Dismissing...
+              </span>
+            ) : "Dismiss"}
           </button>
         </div>
       )}
@@ -1606,6 +1629,15 @@ export default function SystemDetail() {
         confirmLabel="Reboot"
         danger
         loading={rebooting}
+      />
+      <ConfirmDialog
+        open={showDismissNeedsRebootConfirm}
+        onClose={() => setShowDismissNeedsRebootConfirm(false)}
+        onConfirm={handleDismissNeedsReboot}
+        title="Dismiss Reboot Warning"
+        message={`Dismiss the reboot warning for ${system.name}? A later system scan can show it again if the host still reports a reboot-required state or another update requires a reboot.`}
+        confirmLabel="Dismiss Warning"
+        loading={dismissingNeedsReboot}
       />
       <ConfirmDialog
         open={pendingHideUpdate !== null}

--- a/server/routes/systems.ts
+++ b/server/routes/systems.ts
@@ -692,6 +692,24 @@ systems.post("/:id/reboot", async (c) => {
   return c.json(result, result.success ? 200 : 500);
 });
 
+systems.post("/:id/dismiss-needs-reboot", async (c) => {
+  const id = parseId(c.req.param("id"));
+  if (!id) return c.json({ error: "Invalid system ID" }, 400);
+  const system = systemService.getSystem(id);
+  if (!system) return c.json({ error: "System not found" }, 404);
+
+  try {
+    systemService.dismissNeedsReboot(id);
+  } catch (error) {
+    const response = getSystemWriteErrorResponse(error);
+    if (response) return response;
+    throw error;
+  }
+
+  await notificationRuntime.syncSystemState(id);
+  return c.json({ status: "ok" });
+});
+
 systems.post("/:id/revoke-host-key", (c) => {
   const id = parseId(c.req.param("id"));
   if (!id) return c.json({ error: "Invalid system ID" }, 400);

--- a/server/services/system-service.ts
+++ b/server/services/system-service.ts
@@ -430,6 +430,20 @@ export function deleteSystem(systemId: number): void {
   db.delete(systems).where(eq(systems.id, systemId)).run();
 }
 
+export function dismissNeedsReboot(systemId: number): void {
+  const db = getDb();
+  const existing = getSystem(systemId);
+  if (!existing) throw new Error("System not found");
+
+  db.update(systems)
+    .set({
+      needsReboot: 0,
+      updatedAt: new Date().toISOString().replace("T", " ").slice(0, 19),
+    })
+    .where(eq(systems.id, systemId))
+    .run();
+}
+
 export function reorderSystems(systemIds: number[]): void {
   const db = getDb();
   const existingSystems = db

--- a/server/ssh/system-info.ts
+++ b/server/ssh/system-info.ts
@@ -7,6 +7,7 @@ export const SYSTEM_INFO_CMD =
   'echo "===KERNEL==="; uname -r 2>/dev/null; ' +
   'echo "===HOSTNAME==="; (hostname 2>/dev/null || cat /etc/hostname 2>/dev/null); ' +
   'echo "===UPTIME==="; (uptime -p 2>/dev/null || uptime 2>/dev/null); ' +
+  'echo "===UPTIME_SECONDS==="; cut -d " " -f1 /proc/uptime 2>/dev/null; ' +
   'echo "===ARCH==="; uname -m 2>/dev/null; ' +
   'echo "===CPU==="; nproc 2>/dev/null; ' +
   'echo "===MEM==="; free -h 2>/dev/null | grep Mem; ' +
@@ -27,6 +28,7 @@ export interface SystemInfo {
   kernel: string;
   hostname: string;
   uptime: string;
+  uptimeSeconds: number | null;
   arch: string;
   cpuCores: string;
   memory: string;
@@ -40,7 +42,10 @@ export interface SystemInfo {
 
 export interface PreviousRebootState {
   bootId?: string | null;
+  lastSeenAt?: string | null;
 }
+
+const STALE_REBOOT_UPTIME_TOLERANCE_SECONDS = 120;
 
 const KERNEL_VERSION_COLLATOR = new Intl.Collator(undefined, {
   numeric: true,
@@ -126,9 +131,44 @@ export function hasPendingKernelUpdate(
   return familyKernels[familyKernels.length - 1] !== running;
 }
 
+function parseDbTimestampAsUtcMillis(value: string | null | undefined): number | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+
+  const match = trimmed.match(
+    /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/
+  );
+  if (!match) return null;
+
+  const [, year, month, day, hour, minute, second] = match;
+  return Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second)
+  );
+}
+
+function rebootCanBeInferredFromUptime(
+  previous: PreviousRebootState | null | undefined,
+  info: SystemInfo,
+  now = Date.now()
+): boolean {
+  if (info.uptimeSeconds == null) return false;
+
+  const lastSeenAtMs = parseDbTimestampAsUtcMillis(previous?.lastSeenAt);
+  if (lastSeenAtMs == null) return false;
+
+  const elapsedSeconds = (now - lastSeenAtMs) / 1000;
+  return elapsedSeconds > info.uptimeSeconds + STALE_REBOOT_UPTIME_TOLERANCE_SECONDS;
+}
+
 export function resolveRebootRequired(
   previous: PreviousRebootState | null | undefined,
-  info: SystemInfo
+  info: SystemInfo,
+  now = Date.now()
 ): boolean {
   if (info.needsRestartingStatus === "required") {
     return true;
@@ -149,6 +189,13 @@ export function resolveRebootRequired(
     return false;
   }
 
+  if (
+    (!previousBootId || !currentBootId || previousBootId === currentBootId) &&
+    rebootCanBeInferredFromUptime(previous, info, now)
+  ) {
+    return false;
+  }
+
   return true;
 }
 
@@ -159,6 +206,7 @@ export function parseSystemInfo(stdout: string): SystemInfo {
     kernel: "",
     hostname: "",
     uptime: "",
+    uptimeSeconds: null,
     arch: "",
     cpuCores: "",
     memory: "",
@@ -208,6 +256,12 @@ export function parseSystemInfo(stdout: string): SystemInfo {
   info.kernel = (sections["KERNEL"] || "").trim();
   info.hostname = (sections["HOSTNAME"] || "").trim();
   info.uptime = (sections["UPTIME"] || "").trim();
+
+  const uptimeSeconds = Number.parseFloat((sections["UPTIME_SECONDS"] || "").trim());
+  if (Number.isFinite(uptimeSeconds) && uptimeSeconds >= 0) {
+    info.uptimeSeconds = uptimeSeconds;
+  }
+
   info.arch = (sections["ARCH"] || "").trim();
   info.cpuCores = (sections["CPU"] || "").trim();
 

--- a/tests/server/system-info.test.ts
+++ b/tests/server/system-info.test.ts
@@ -19,6 +19,8 @@ ID=ubuntu
 web-server-01
 ===UPTIME===
 up 14 days, 3 hours, 22 minutes
+===UPTIME_SECONDS===
+1234567.89
 ===ARCH===
 x86_64
 ===CPU===
@@ -43,6 +45,7 @@ PRESENT
     expect(info.kernel).toBe("6.8.0-45-generic");
     expect(info.hostname).toBe("web-server-01");
     expect(info.uptime).toContain("14 days");
+    expect(info.uptimeSeconds).toBe(1234567.89);
     expect(info.arch).toBe("x86_64");
     expect(info.cpuCores).toBe("4");
     expect(info.memory).toBe("7.7Gi");
@@ -65,6 +68,8 @@ NAME="Unknown"
 srv
 ===UPTIME===
 up 1 hour
+===UPTIME_SECONDS===
+3600.12
 ===ARCH===
 aarch64
 ===CPU===
@@ -76,6 +81,7 @@ aarch64
     expect(info.osName).toBe("Unknown");
     expect(info.kernel).toBe("5.0");
     expect(info.hostname).toBe("srv");
+    expect(info.uptimeSeconds).toBe(3600.12);
     expect(info.arch).toBe("aarch64");
   });
 
@@ -101,6 +107,8 @@ Raspberry Pi reference 2025-02-12
 pi
 ===UPTIME===
 up 2 days
+===UPTIME_SECONDS===
+172800
 ===ARCH===
 aarch64
 ===CPU===
@@ -132,6 +140,8 @@ pve-manager/9.0.3/abc12345
 proxmox
 ===UPTIME===
 up 7 days
+===UPTIME_SECONDS===
+604800
 ===ARCH===
 x86_64
 ===CPU===
@@ -162,6 +172,8 @@ ID=debian
 domain
 ===UPTIME===
 up 3 days
+===UPTIME_SECONDS===
+259200
 ===ARCH===
 x86_64
 ===CPU===
@@ -208,6 +220,8 @@ NAME="Debian"
 pi
 ===UPTIME===
 up 1 hour
+===UPTIME_SECONDS===
+3600
 ===ARCH===
 x86_64
 ===CPU===
@@ -238,6 +252,8 @@ NAME="Debian"
 pi
 ===UPTIME===
 up 4 minutes
+===UPTIME_SECONDS===
+240
 ===ARCH===
 x86_64
 ===CPU===
@@ -259,6 +275,124 @@ UNAVAILABLE
     expect(resolveRebootRequired({ bootId: "boot-a" }, info)).toBe(false);
   });
 
+  test("clears stale reboot-required file when boot id is unchanged but uptime proves a reboot", () => {
+    const info = parseSystemInfo(`===OS===
+NAME="Debian"
+===KERNEL===
+6.1.0-30-amd64
+===HOSTNAME===
+pi
+===UPTIME===
+up 4 minutes
+===UPTIME_SECONDS===
+240
+===ARCH===
+x86_64
+===CPU===
+4
+===MEM===
+Mem: 1Gi
+===DISK===
+/dev/root 20G 5G 15G 25% /
+===BOOT_ID===
+boot-a
+===REBOOT_FILE===
+PRESENT
+===NEEDS_RESTARTING===
+UNAVAILABLE
+===INSTALLED_KERNELS===
+6.1.0-30-amd64
+`);
+
+    const now = Date.UTC(2026, 3, 14, 12, 0, 0);
+    expect(
+      resolveRebootRequired(
+        { bootId: "boot-a", lastSeenAt: "2026-04-14 11:50:00" },
+        info,
+        now
+      )
+    ).toBe(false);
+  });
+
+  test("keeps reboot required when boot id is unchanged and uptime does not prove a reboot", () => {
+    const info = parseSystemInfo(`===OS===
+NAME="Debian"
+===KERNEL===
+6.1.0-30-amd64
+===HOSTNAME===
+pi
+===UPTIME===
+up 9 minutes
+===UPTIME_SECONDS===
+540
+===ARCH===
+x86_64
+===CPU===
+4
+===MEM===
+Mem: 1Gi
+===DISK===
+/dev/root 20G 5G 15G 25% /
+===BOOT_ID===
+boot-a
+===REBOOT_FILE===
+PRESENT
+===NEEDS_RESTARTING===
+UNAVAILABLE
+===INSTALLED_KERNELS===
+6.1.0-30-amd64
+`);
+
+    const now = Date.UTC(2026, 3, 14, 12, 0, 0);
+    expect(
+      resolveRebootRequired(
+        { bootId: "boot-a", lastSeenAt: "2026-04-14 11:50:00" },
+        info,
+        now
+      )
+    ).toBe(true);
+  });
+
+  test("keeps reboot required for pending kernel updates even if uptime suggests a reboot", () => {
+    const info = parseSystemInfo(`===OS===
+NAME="Debian"
+===KERNEL===
+6.1.0-30-amd64
+===HOSTNAME===
+pi
+===UPTIME===
+up 4 minutes
+===UPTIME_SECONDS===
+240
+===ARCH===
+x86_64
+===CPU===
+4
+===MEM===
+Mem: 1Gi
+===DISK===
+/dev/root 20G 5G 15G 25% /
+===BOOT_ID===
+boot-a
+===REBOOT_FILE===
+PRESENT
+===NEEDS_RESTARTING===
+UNAVAILABLE
+===INSTALLED_KERNELS===
+6.1.0-30-amd64
+6.1.0-31-amd64
+`);
+
+    const now = Date.UTC(2026, 3, 14, 12, 0, 0);
+    expect(
+      resolveRebootRequired(
+        { bootId: "boot-a", lastSeenAt: "2026-04-14 11:50:00" },
+        info,
+        now
+      )
+    ).toBe(true);
+  });
+
   test("keeps reboot required when needs-restarting reports it", () => {
     const info = parseSystemInfo(`===OS===
 NAME="Rocky Linux"
@@ -268,6 +402,8 @@ NAME="Rocky Linux"
 db
 ===UPTIME===
 up 1 day
+===UPTIME_SECONDS===
+240
 ===ARCH===
 x86_64
 ===CPU===
@@ -286,6 +422,13 @@ ABSENT
 5.14.0-503.14.1.el9_5.x86_64
 `);
 
-    expect(resolveRebootRequired({ bootId: "boot-b" }, info)).toBe(true);
+    const now = Date.UTC(2026, 3, 14, 12, 0, 0);
+    expect(
+      resolveRebootRequired(
+        { bootId: "boot-b", lastSeenAt: "2026-04-14 11:50:00" },
+        info,
+        now
+      )
+    ).toBe(true);
   });
 });

--- a/tests/server/system-service.test.ts
+++ b/tests/server/system-service.test.ts
@@ -8,6 +8,7 @@ import { closeDatabase, getDb, initDatabase } from "../../server/db";
 import { systems } from "../../server/db/schema";
 import { initEncryptor } from "../../server/security";
 import {
+  dismissNeedsReboot,
   filterVisibleSystemIds,
   filterVisibleSystemItems,
   isSystemVisible,
@@ -50,6 +51,8 @@ VERSION_ID="12"
 pi
 ===UPTIME===
 up 3 days
+===UPTIME_SECONDS===
+259200
 ===ARCH===
 aarch64
 ===CPU===
@@ -77,6 +80,8 @@ VERSION_ID="12"
 pi
 ===UPTIME===
 up 2 minutes
+===UPTIME_SECONDS===
+120
 ===ARCH===
 aarch64
 ===CPU===
@@ -86,7 +91,7 @@ Mem:           7.7Gi       2.1Gi       4.2Gi       256Mi       1.4Gi       5.3Gi
 ===DISK===
 /dev/root        50G   12G   35G  26% /
 ===BOOT_ID===
-boot-new
+boot-old
 ===REBOOT_FILE===
 PRESENT
 ===NEEDS_RESTARTING===
@@ -111,11 +116,54 @@ UNAVAILABLE
     expect(system?.needsReboot).toBe(1);
     expect(system?.bootId).toBe("boot-old");
 
-    await updateSystemInfo(inserted.id, sshManager, {} as never);
+    db.update(systems)
+      .set({ lastSeenAt: "2026-04-14 10:00:00" })
+      .where(eq(systems.id, inserted.id))
+      .run();
+
+    const realDateNow = Date.now;
+    Date.now = () => Date.UTC(2026, 3, 14, 12, 30, 0);
+    try {
+      await updateSystemInfo(inserted.id, sshManager, {} as never);
+    } finally {
+      Date.now = realDateNow;
+    }
 
     system = db.select().from(systems).where(eq(systems.id, inserted.id)).get();
     expect(system?.needsReboot).toBe(0);
-    expect(system?.bootId).toBe("boot-new");
+    expect(system?.bootId).toBe("boot-old");
+  });
+});
+
+describe("dismissNeedsReboot", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "ludash-dismiss-reboot-test-"));
+    initEncryptor(randomBytes(32).toString("base64"));
+    initDatabase(join(tempDir, "dashboard.db"));
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("clears the stored reboot-required flag", () => {
+    const db = getDb();
+    const inserted = db.insert(systems).values({
+      name: "Pi",
+      hostname: "pi.local",
+      port: 22,
+      authType: "password",
+      username: "pi",
+      needsReboot: 1,
+    }).returning({ id: systems.id }).get();
+
+    dismissNeedsReboot(inserted.id);
+
+    const system = db.select().from(systems).where(eq(systems.id, inserted.id)).get();
+    expect(system?.needsReboot).toBe(0);
   });
 });
 


### PR DESCRIPTION
- Use reboot time as fall back if the boot_id doesn't change between reboots
- Add a button for manual dismissal of the reboot required warning 
- Closes #128