### PR TITLE
Add pre-reboot safety checks , clarify script runtime behavior and improve upgrade all modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 <div align="center">
 
-  [![Build](https://img.shields.io/github/actions/workflow/status/TheDuffman85/linux-update-dashboard/release.yml?style=flat-square&logo=github&label=build)](https://github.com/TheDuffman85/linux-update-dashboard/actions/workflows/release.yml)
-  [![Trivy Scan](https://img.shields.io/github/actions/workflow/status/TheDuffman85/linux-update-dashboard/trivy-scan.yml?style=flat-square&logo=aqua&label=security)](https://github.com/TheDuffman85/linux-update-dashboard/actions/workflows/trivy-scan.yml)
-  [![GitHub License](https://img.shields.io/github/license/TheDuffman85/linux-update-dashboard?style=flat-square&logo=github)](https://github.com/TheDuffman85/linux-update-dashboard/blob/main/LICENSE)
-  [![GitHub last commit](https://img.shields.io/github/last-commit/TheDuffman85/linux-update-dashboard?style=flat-square&logo=github)](https://github.com/TheDuffman85/linux-update-dashboard/commits/main)
-  [![Latest Container](https://img.shields.io/badge/ghcr.io-latest-blue?style=flat-square&logo=github)](https://github.com/users/TheDuffman85/packages/container/package/linux-update-dashboard)
+[![Build](https://img.shields.io/github/actions/workflow/status/TheDuffman85/linux-update-dashboard/release.yml?style=flat-square&logo=github&label=build)](https://github.com/TheDuffman85/linux-update-dashboard/actions/workflows/release.yml)
+[![Trivy Scan](https://img.shields.io/github/actions/workflow/status/TheDuffman85/linux-update-dashboard/trivy-scan.yml?style=flat-square&logo=aqua&label=security)](https://github.com/TheDuffman85/linux-update-dashboard/actions/workflows/trivy-scan.yml)
+[![GitHub License](https://img.shields.io/github/license/TheDuffman85/linux-update-dashboard?style=flat-square&logo=github)](https://github.com/TheDuffman85/linux-update-dashboard/blob/main/LICENSE)
+[![GitHub last commit](https://img.shields.io/github/last-commit/TheDuffman85/linux-update-dashboard?style=flat-square&logo=github)](https://github.com/TheDuffman85/linux-update-dashboard/commits/main)
+[![Latest Container](https://img.shields.io/badge/ghcr.io-latest-blue?style=flat-square&logo=github)](https://github.com/users/TheDuffman85/packages/container/package/linux-update-dashboard)
 
 </div>
 
@@ -35,8 +35,8 @@ A self-hosted web app for managing Linux package updates across multiple servers
 - **Auto-detection:** package managers and system info are detected automatically on first connection; you can disable individual managers per system
 - **Per-system package-manager behavior:** configure manager-specific upgrade/check behavior such as APT full-upgrade defaults, DNF distro-sync defaults, and refresh toggles for DNF, Pacman, APK, and Flatpak
 - **Script customization:** inspect built-in SSH command scripts, copy them into editable custom scripts, add custom package managers, and assign per-system script overrides
-- **Granular updates:** upgrade everything at once or pick individual packages per system
-- **Background scheduling:** periodic checks keep your dashboard up to date with a configurable scheduler interval and cache duration
+- **Granular updates:** upgrade everything at once, queue grouped Upgrade All batches, or pick individual packages per system
+- **Cron-based scheduling:** create refresh, update, and notification schedules with per-schedule system scope and cache behavior
 - **APT kept-back auto-hide:** optionally move kept-back APT packages into the hidden-updates list for specific systems so they disappear from visible counts and dashboards
 - **Flexible notifications:** set up multiple channels per event type (Email/SMTP, Gotify, MQTT, ntfy.sh, Telegram, Webhooks), scope them to specific systems, and pick which events trigger each channel
 - **Home Assistant MQTT update entities:** publish one Linux Update Dashboard app update entity plus per-system package update entities with discovery, icons/images, rich JSON attributes, and optional install commands
@@ -49,6 +49,7 @@ A self-hosted web app for managing Linux package updates across multiple servers
 - **Remote reboot:** trigger reboots from the UI with a dashboard-wide reboot-needed indicator
 - **System duplication:** clone an existing system entry (including encrypted credentials) to quickly add similar servers
 - **Exclude from Upgrade All:** make individual systems start unchecked in the Upgrade All Systems dialog
+- **Upgrade groups:** organize systems into ordered groups so Upgrade All can run systems in the same group together before moving to the next group
 - **Visibility controls:** hide systems from the main dashboard without deleting them
 - **Notification schedules:** deliver notifications immediately or batch them on one or more cron-based schedules
 - **Dark mode:** dark/light theme with OS preference detection
@@ -60,47 +61,56 @@ A self-hosted web app for managing Linux package updates across multiple servers
 ## Screenshots
 
 ### Dashboard
+
 Overview of all systems with summary cards, update totals, and color-coded status tiles for quick triage.
 
 ![Dashboard](screenshots/1.png)
 
 ### System Detail
+
 Detailed system view with connection data, OS and resource information, available updates, and expandable activity output.
 
 ![System Detail](screenshots/2.png)
 
 ### Systems List
+
 Table view of all configured systems with OS, status, update counts, last check time, and quick actions.
 
 ![Systems List](screenshots/3.png)
 
 ### Edit System
+
 Edit an existing system's connection settings, SSH credential, host-key approval, and visibility options.
 
 ![Edit System](screenshots/4.png)
 
 ### Credentials
+
 Manage saved SSH credentials and see which systems reference each one.
 
 ![Credentials](screenshots/5.png)
 
 ### Add Credential
+
 Create a new SSH key or password credential for reuse across systems.
 
 ![Add Credential](screenshots/6.png)
 
 ### Notifications
+
 Manage notification channels with delivery status, enabled state, supported events, and per-channel actions.
 
 ![Notifications](screenshots/7.png)
 
 ### Add Notification
+
 Configure a new notification channel with event filters, system scope, schedule, and provider-specific fields.
 
 ![Add Notification](screenshots/8.png)
 
 ### Settings
-Configure scheduler intervals, SSH timeouts, password settings, and other application options.
+
+Configure activity history retention, SSH timeouts, password settings, SSO, passkeys, and API tokens.
 
 ![Settings](screenshots/9.png)
 
@@ -297,26 +307,26 @@ docker inspect --format='{{.State.Health.Status}}' linux-update-dashboard
 
 ## Environment Variables
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `LUDASH_ENCRYPTION_KEY` | **Yes** | - | AES-256 key for encrypting stored SSH credentials |
-| `LUDASH_ENCRYPTION_KEY_FILE` | No | - | Optional alternative: read `LUDASH_ENCRYPTION_KEY` value from file (Docker secrets) |
-| `LUDASH_DB_PATH` | No | `./data/dashboard.db` | SQLite database file path |
-| `LUDASH_SECRET_KEY` | No | Auto-generated | JWT session signing secret (auto-persisted to `.secret_key`) |
-| `LUDASH_SECRET_KEY_FILE` | No | Auto-generated | Read `LUDASH_SECRET_KEY` value from file (Docker secrets) |
-| `LUDASH_PORT` | No | `3001` | HTTP server port |
-| `LUDASH_HOST` | No | `0.0.0.0` | HTTP server bind address |
-| `LUDASH_BASE_URL` | No | `http://localhost:3001` | Recommended to always set. Public URL used for WebAuthn/OIDC and Home Assistant URLs such as `entity_picture`/`origin.url`. Set it to the URL users and integrations actually use |
-| `LUDASH_TRUST_PROXY` | No | `false` | Set to `true` behind a reverse proxy so `X-Forwarded-*` headers are trusted. Recommended whenever the public URL is provided by a proxy |
-| `TZ` | No | `UTC` | Standard container timezone used by Docker and Node.js. Set it to a value like `Europe/Berlin` if you want the UI and notification times to use a specific timezone |
-| `LUDASH_LOG_LEVEL` | No | `info` | Server log level: `debug`, `info`, `warn`, or `error`. Routine per-attempt SSH and scheduler refresh logs are only shown at `debug` |
-| `LUDASH_DEFAULT_CACHE_HOURS` | No | `12` | How long update results are reused before re-checking; `0` disables cache reuse |
-| `LUDASH_DEFAULT_SSH_TIMEOUT` | No | `30` | SSH connection timeout in seconds |
-| `LUDASH_DEFAULT_CMD_TIMEOUT` | No | `120` | SSH command execution timeout in seconds |
-| `LUDASH_MAX_CONCURRENT_CONNECTIONS` | No | `5` | Max simultaneous SSH connections |
-| `LUDASH_MIN_SCHEDULE_INTERVAL_MINUTES` | No | `5` | Minimum allowed interval for cron-based schedules |
-| `NODE_EXTRA_CA_CERTS` | No | - | Path to a PEM CA bundle to trust additional/self-signed certificates for outbound TLS (OIDC, SMTP, Gotify, ntfy, webhooks, etc.) |
-| `NODE_ENV` | No | - | Set to `production` for static file serving |
+| Variable                               | Required | Default                 | Description                                                                                                                                                                       |
+| -------------------------------------- | -------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LUDASH_ENCRYPTION_KEY`                | **Yes**  | -                       | AES-256 key for encrypting stored SSH credentials                                                                                                                                 |
+| `LUDASH_ENCRYPTION_KEY_FILE`           | No       | -                       | Optional alternative: read `LUDASH_ENCRYPTION_KEY` value from file (Docker secrets)                                                                                               |
+| `LUDASH_DB_PATH`                       | No       | `./data/dashboard.db`   | SQLite database file path                                                                                                                                                         |
+| `LUDASH_SECRET_KEY`                    | No       | Auto-generated          | JWT session signing secret (auto-persisted to `.secret_key`)                                                                                                                      |
+| `LUDASH_SECRET_KEY_FILE`               | No       | Auto-generated          | Read `LUDASH_SECRET_KEY` value from file (Docker secrets)                                                                                                                         |
+| `LUDASH_PORT`                          | No       | `3001`                  | HTTP server port                                                                                                                                                                  |
+| `LUDASH_HOST`                          | No       | `0.0.0.0`               | HTTP server bind address                                                                                                                                                          |
+| `LUDASH_BASE_URL`                      | No       | `http://localhost:3001` | Recommended to always set. Public URL used for WebAuthn/OIDC and Home Assistant URLs such as `entity_picture`/`origin.url`. Set it to the URL users and integrations actually use |
+| `LUDASH_TRUST_PROXY`                   | No       | `false`                 | Set to `true` behind a reverse proxy so `X-Forwarded-*` headers are trusted. Recommended whenever the public URL is provided by a proxy                                           |
+| `TZ`                                   | No       | `UTC`                   | Standard container timezone used by Docker and Node.js. Set it to a value like `Europe/Berlin` if you want the UI and notification times to use a specific timezone               |
+| `LUDASH_LOG_LEVEL`                     | No       | `info`                  | Server log level: `debug`, `info`, `warn`, or `error`. Routine per-attempt SSH and scheduler refresh logs are only shown at `debug`                                               |
+| `LUDASH_DEFAULT_CACHE_HOURS`           | No       | `12`                    | How long update results are reused before re-checking; `0` disables cache reuse                                                                                                   |
+| `LUDASH_DEFAULT_SSH_TIMEOUT`           | No       | `30`                    | SSH connection timeout in seconds                                                                                                                                                 |
+| `LUDASH_DEFAULT_CMD_TIMEOUT`           | No       | `120`                   | SSH command execution timeout in seconds                                                                                                                                          |
+| `LUDASH_MAX_CONCURRENT_CONNECTIONS`    | No       | `5`                     | Max simultaneous SSH connections                                                                                                                                                  |
+| `LUDASH_MIN_SCHEDULE_INTERVAL_MINUTES` | No       | `5`                     | Minimum allowed interval for cron-based schedules                                                                                                                                 |
+| `NODE_EXTRA_CA_CERTS`                  | No       | -                       | Path to a PEM CA bundle to trust additional/self-signed certificates for outbound TLS (OIDC, SMTP, Gotify, ntfy, webhooks, etc.)                                                  |
+| `NODE_ENV`                             | No       | -                       | Set to `production` for static file serving                                                                                                                                       |
 
 If you use `LUDASH_ENCRYPTION_KEY_FILE`, do not also set `LUDASH_ENCRYPTION_KEY`. If both `VAR` and `VAR_FILE` are set for the same setting, startup fails with a configuration error.
 
@@ -333,6 +343,12 @@ cache duration settings.
 Schedules use standard five-field cron expressions in the container timezone. Set the Docker `TZ` environment variable, such as `TZ=Europe/Berlin`, when you want schedules to follow a local timezone instead of UTC. The default minimum interval is **5 minutes**; schedules that run more frequently are rejected by the API. Set `LUDASH_MIN_SCHEDULE_INTERVAL_MINUTES` to adjust the server-side limit. If you build the client yourself and change the server limit, set `VITE_MIN_SCHEDULE_INTERVAL_MINUTES` to the same value so UI warnings match.
 
 Set a refresh schedule's cache duration to `0` to disable cache reuse. Manual refreshes, server restarts, and newly added systems can still trigger immediate checks outside configured schedules. Notification channels can be assigned to multiple notification schedules, and the same pending event batch is delivered when any selected schedule runs.
+
+## Upgrade All Groups
+
+The **Upgrade All Systems** dialog can save an upgrade order with optional groups. Systems in the same group run together; the next group starts only after every queued system in the current group finishes. Ungrouped systems are kept in the same ordered flow and can be positioned before, between, or after named groups.
+
+Use edit mode in the dialog to create, rename, delete, and reorder groups, or drag systems between groups. Hidden systems and systems excluded from Upgrade All are not queued unless you explicitly include eligible visible systems in the dialog.
 
 ## Debugging SSH Connection Failures
 
@@ -403,6 +419,7 @@ Bearer tokens for external API consumers (e.g. [gethomepage](https://gethomepage
 - **Rate-limited:** failed bearer attempts are rate-limited (20/min per IP), max 25 tokens per user
 
 Usage:
+
 ```bash
 curl -H "Authorization: Bearer ludash_..." http://localhost:3001/api/dashboard/stats
 ```
@@ -427,14 +444,14 @@ Scheduled delivery buffers matching events until the next selected schedule runs
 
 ### Channel Overview
 
-| Type | Best for | Notes |
-|------|----------|-------|
-| `Email` | inbox-based alerts | SMTP transport with optional auth and importance override |
-| `Gotify` | mobile/self-hosted push | app token stored encrypted |
-| `MQTT` | brokers, automations, and Home Assistant | generic event publishing plus optional Home Assistant MQTT Update entities |
-| `ntfy` | lightweight push topics | topic-based delivery with optional bearer token |
-| `Telegram` | chat notifications and optional remote actions | private-chat only |
-| `Webhook` | integrations with automation tools, chat ops, and custom receivers | supports templates, auth, retries, and a Discord preset |
+| Type       | Best for                                                           | Notes                                                                      |
+| ---------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| `Email`    | inbox-based alerts                                                 | SMTP transport with optional auth and importance override                  |
+| `Gotify`   | mobile/self-hosted push                                            | app token stored encrypted                                                 |
+| `MQTT`     | brokers, automations, and Home Assistant                           | generic event publishing plus optional Home Assistant MQTT Update entities |
+| `ntfy`     | lightweight push topics                                            | topic-based delivery with optional bearer token                            |
+| `Telegram` | chat notifications and optional remote actions                     | private-chat only                                                          |
+| `Webhook`  | integrations with automation tools, chat ops, and custom receivers | supports templates, auth, retries, and a Discord preset                    |
 
 ### Email / SMTP
 
@@ -649,15 +666,15 @@ The `discord` preset keeps the webhook in JSON mode and uses a Discord embed pay
 
 ## Supported Package Managers
 
-| Package Manager | Distributions |
-|----------------|---------------|
-| APT | Debian, Ubuntu, Linux Mint |
-| DNF | Fedora, RHEL 8+, AlmaLinux, Rocky |
-| YUM | CentOS, older RHEL |
-| Pacman | Arch Linux, Manjaro |
-| APK | Alpine Linux |
-| Flatpak | Any (cross-distribution) |
-| Snap | Any (cross-distribution) |
+| Package Manager | Distributions                     |
+| --------------- | --------------------------------- |
+| APT             | Debian, Ubuntu, Linux Mint        |
+| DNF             | Fedora, RHEL 8+, AlmaLinux, Rocky |
+| YUM             | CentOS, older RHEL                |
+| Pacman          | Arch Linux, Manjaro               |
+| APK             | Alpine Linux                      |
+| Flatpak         | Any (cross-distribution)          |
+| Snap            | Any (cross-distribution)          |
 
 Package managers are auto-detected on each system over SSH when you test the connection or run the first check. Detected managers are enabled by default, and you can toggle them individually per system in the edit dialog. Security updates are identified where possible (e.g. APT security repos).
 
@@ -684,15 +701,15 @@ The **Scripts** page exposes the SSH command templates that power package-manage
 
 Script commands support placeholders that are resolved immediately before SSH execution:
 
-| Placeholder | Meaning |
-|-------------|---------|
-| `{{package}}` | First selected package name after package-name validation |
-| `{{packages}}` | All selected package names joined with spaces after validation |
-| `{{quotedPackage}}` | First selected package shell-quoted with single quotes |
-| `{{quotedPackages}}` | All selected packages shell-quoted and joined with spaces |
-| `{{manager}}` | Current package-manager key, such as `apt` or a custom manager name |
+| Placeholder          | Meaning                                                                               |
+| -------------------- | ------------------------------------------------------------------------------------- |
+| `{{package}}`        | First selected package name after package-name validation                             |
+| `{{packages}}`       | All selected package names joined with spaces after validation                        |
+| `{{quotedPackage}}`  | First selected package shell-quoted with single quotes                                |
+| `{{quotedPackages}}` | All selected packages shell-quoted and joined with spaces                             |
+| `{{manager}}`        | Current package-manager key, such as `apt` or a custom manager name                   |
 | `{{config.someKey}}` | Per-system package-manager config value, including custom config entries and defaults |
-| `{{sudo:COMMAND}}` | Wraps `COMMAND` with the dashboard sudo fallback helper |
+| `{{sudo:COMMAND}}`   | Wraps `COMMAND` with the dashboard sudo fallback helper                               |
 
 For custom update parsers, the update regex should use named capture groups. `packageName` and `newVersion` are required for an update to be recorded; optional groups include `currentVersion`, `architecture`, and `repository`. Separate security and kept-back regexes can mark matching lines. Custom success and update exit-code lists are available for package managers whose check command uses non-zero exit codes to mean "updates available".
 
@@ -721,7 +738,7 @@ Custom system-info scripts can either keep the built-in sectioned parser or map 
 │   ├── routes/               # API route handlers
 │   ├── services/             # Business logic, caching, scheduling
 │   └── ssh/                  # SSH connection manager + parsers
-├── tests/server/             # Bun test suites
+├── tests/server/             # Vitest server test suites
 ├── docker/                   # Dockerfile, compose, entrypoint
 │   └── test-systems/         # Docker test containers
 ├── run.sh                    # Local dev/production/test runner
@@ -735,11 +752,13 @@ Custom system-info scripts can either keep the built-in sectioned parser or map 
 There's a helper script `run.sh` to manage services.
 
 **Development mode** (hot reload, server on :3001, client on :5173):
+
 ```bash
 ./run.sh dev
 ```
 
 **Production mode** (build and start on :3001):
+
 ```bash
 ./run.sh
 ```
@@ -760,6 +779,7 @@ pnpm test
 # Type check
 pnpm run check
 ```
+
 The app creates and upgrades the SQLite schema automatically on startup.
 
 ### Test Systems
@@ -767,11 +787,13 @@ The app creates and upgrades the SQLite schema automatically on startup.
 The project includes Docker-based test systems that simulate real Linux servers with pending updates. This lets you develop and test the dashboard without needing actual remote machines.
 
 **Start the dashboard with test systems:**
+
 ```bash
 ./run.sh test
 ```
 
 This will:
+
 1. Stop any running dev/production services
 2. Build and start 14 Docker containers (including Alpine, fish-shell, sudo-password APT, and partial multi-manager fixtures)
 3. Build the frontend in production mode
@@ -780,58 +802,64 @@ This will:
 The server initializes or upgrades the SQLite schema automatically during startup.
 
 **SSH credentials for all test systems:**
+
 - User: `testuser`
 - Password: `testpass`
 - `Sudo password`: `testpass` (required for `ludash-test-ubuntu-sudo` and `ludash-test-debian-fish-sudo`, optional for others)
 - Passwordless `sudo` is pre-configured on all test systems except `ludash-test-ubuntu-sudo` and `ludash-test-debian-fish-sudo`
 
-| Container | SSH Port | Package Manager | Login Shell | Base Image |
-|-----------|----------|-----------------|-------------|------------|
-| `ludash-test-ubuntu` | 2001 | APT | `bash` | Ubuntu 24.04 |
-| `ludash-test-fedora` | 2002 | DNF | `bash` | Fedora 41 |
-| `ludash-test-centos7` | 2003 | YUM | `bash` | CentOS 7 |
-| `ludash-test-archlinux` | 2004 | Pacman | `bash` | Arch Linux |
-| `ludash-test-flatpak` | 2005 | Flatpak | `bash` | Ubuntu 24.04 |
-| `ludash-test-snap` | 2006 | Snap | `bash` | Ubuntu 24.04 |
-| `ludash-test-ubuntu-sudo` | 2007 | APT (sudo password) | `bash` | Ubuntu 24.04 |
-| `ludash-test-debian-fish` | 2008 | APT | `fish` | Debian 12 |
-| `ludash-test-debian-fish-sudo` | 2009 | APT (sudo password) | `fish` | Debian 12 |
-| `ludash-test-alpine` | 2010 | APK | `bash` | Alpine 3.16 |
-| `ludash-test-apt-keptback` | 2011 | APT (kept-back fixture) | `bash` | Debian 12 |
-| `ludash-test-apt-snap-partial` | 2012 | APT + Snap (Snap check fails) | `bash` | Ubuntu 24.04 |
-| `ludash-test-dnf-gpg-prompt` | 2013 | DNF (GPG key prompt fixture) | `bash` | Fedora 41 |
-| `ludash-test-dnf-eula-prompt` | 2014 | DNF (EULA prompt fixture) | `bash` | Fedora 41 |
-| `ludash-test-apt-dpkg-interrupted` | 2015 | APT (interrupted dpkg fixture) | `bash` | Debian 12 |
+| Container                          | SSH Port | Package Manager                | Login Shell | Base Image   |
+| ---------------------------------- | -------- | ------------------------------ | ----------- | ------------ |
+| `ludash-test-ubuntu`               | 2001     | APT                            | `bash`      | Ubuntu 24.04 |
+| `ludash-test-fedora`               | 2002     | DNF                            | `bash`      | Fedora 41    |
+| `ludash-test-centos7`              | 2003     | YUM                            | `bash`      | CentOS 7     |
+| `ludash-test-archlinux`            | 2004     | Pacman                         | `bash`      | Arch Linux   |
+| `ludash-test-flatpak`              | 2005     | Flatpak                        | `bash`      | Ubuntu 24.04 |
+| `ludash-test-snap`                 | 2006     | Snap                           | `bash`      | Ubuntu 24.04 |
+| `ludash-test-ubuntu-sudo`          | 2007     | APT (sudo password)            | `bash`      | Ubuntu 24.04 |
+| `ludash-test-debian-fish`          | 2008     | APT                            | `fish`      | Debian 12    |
+| `ludash-test-debian-fish-sudo`     | 2009     | APT (sudo password)            | `fish`      | Debian 12    |
+| `ludash-test-alpine`               | 2010     | APK                            | `bash`      | Alpine 3.16  |
+| `ludash-test-apt-keptback`         | 2011     | APT (kept-back fixture)        | `bash`      | Debian 12    |
+| `ludash-test-apt-snap-partial`     | 2012     | APT + Snap (Snap check fails)  | `bash`      | Ubuntu 24.04 |
+| `ludash-test-dnf-gpg-prompt`       | 2013     | DNF (GPG key prompt fixture)   | `bash`      | Fedora 41    |
+| `ludash-test-dnf-eula-prompt`      | 2014     | DNF (EULA prompt fixture)      | `bash`      | Fedora 41    |
+| `ludash-test-apt-dpkg-interrupted` | 2015     | APT (interrupted dpkg fixture) | `bash`      | Debian 12    |
 
 To add a test system in the dashboard, use `host.docker.internal` (or `172.17.0.1` on Linux) as the hostname with the corresponding SSH port.
 
 Each container is built with **older package versions** pinned from archived repositories, while current repos remain active. This means `apt list --upgradable`, `dnf check-update`, `pacman -Qu`, `apk list -u`, etc. will always report pending updates — giving you realistic data to work with in the dashboard.
 
 `ludash-test-apt-keptback` is a special fixture with a self-contained local APT repo. It intentionally exposes:
+
 - one normal upgrade: `normal-app`
 - one kept-back upgrade: `keptback-app`
 
 That makes it useful for verifying the dashboard’s `isKeptBack` badge/count behavior without depending on upstream repository state.
 
 `ludash-test-apt-snap-partial` is a special multi-manager fixture. It intentionally exposes:
+
 - a working APT refresh with pending package updates
 - a detected Snap installation whose checks fail because `snapd` is not running inside the container
 
 That makes it useful for verifying the dashboard’s semi-working warning state where one package manager succeeds and another fails in the same check run.
 
 `ludash-test-dnf-gpg-prompt` is a special self-contained DNF fixture. It intentionally exposes:
+
 - one local RPM update: `prompt-app` 1.0 -> 2.0
 - a repository metadata signature whose public key exists on disk but is not yet trusted by RPM
 
 That makes it useful for verifying the dashboard’s fail-closed handling of `dnf check-update` when a new repository signing key would normally trigger an interactive `Is this ok [y/N]` prompt.
 
 `ludash-test-dnf-eula-prompt` is a special self-contained DNF fixture. It intentionally exposes:
+
 - one local RPM update: `eula-app` 1.0 -> 2.0
 - an upgrade `%pre` scriptlet that reads from `/dev/tty` unless `ACCEPT_EULA=Y` is set
 
 That makes it useful for verifying the dashboard’s opt-in DNF/YUM EULA automation for non-interactive upgrades without depending on third-party repositories.
 
 `ludash-test-apt-dpkg-interrupted` is a special APT fixture. It intentionally leaves a local package in a failed configure state so APT commands report:
+
 - `dpkg was interrupted, you must manually run 'sudo dpkg --configure -a'`
 
 That makes it useful for verifying the package manager issue banner, including the **Solve** action that runs `dpkg --configure -a` and then rechecks updates.
@@ -841,6 +869,7 @@ The Docker Compose file and all Dockerfiles are in [`docker/test-systems/`](dock
 ### Branch Management
 
 To reset the `dev` branch to match `main` (force push):
+
 ```bash
 ./reset-dev-branch.sh
 ```
@@ -851,134 +880,149 @@ All endpoints require authentication unless noted. Responses are JSON.
 
 ### Health
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/health` | Health check (localhost: no auth, external: requires auth) |
+| Method | Endpoint      | Description                                                |
+| ------ | ------------- | ---------------------------------------------------------- |
+| GET    | `/api/health` | Health check (localhost: no auth, external: requires auth) |
 
 ### Auth (`/api/auth/*`)
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/auth/status` | Auth state, setup status, OIDC availability |
-| POST | `/api/auth/setup` | Create initial admin account |
-| POST | `/api/auth/login` | Password login |
-| POST | `/api/auth/logout` | Clear session |
-| GET | `/api/auth/me` | Current user info |
-| POST | `/api/auth/change-password` | Change the current user's password |
-| POST | `/api/auth/webauthn/register/options` | Start passkey registration |
-| POST | `/api/auth/webauthn/register/verify` | Complete passkey registration |
-| POST | `/api/auth/webauthn/login/options` | Start passkey login |
-| POST | `/api/auth/webauthn/login/verify` | Complete passkey login |
-| GET | `/api/auth/oidc/login` | Redirect to OIDC provider |
-| GET | `/api/auth/oidc/callback` | OIDC callback handler |
+| Method | Endpoint                              | Description                                 |
+| ------ | ------------------------------------- | ------------------------------------------- |
+| GET    | `/api/auth/status`                    | Auth state, setup status, OIDC availability |
+| POST   | `/api/auth/setup`                     | Create initial admin account                |
+| POST   | `/api/auth/login`                     | Password login                              |
+| POST   | `/api/auth/logout`                    | Clear session                               |
+| GET    | `/api/auth/me`                        | Current user info                           |
+| POST   | `/api/auth/change-password`           | Change the current user's password          |
+| POST   | `/api/auth/webauthn/register/options` | Start passkey registration                  |
+| POST   | `/api/auth/webauthn/register/verify`  | Complete passkey registration               |
+| POST   | `/api/auth/webauthn/login/options`    | Start passkey login                         |
+| POST   | `/api/auth/webauthn/login/verify`     | Complete passkey login                      |
+| GET    | `/api/auth/oidc/login`                | Redirect to OIDC provider                   |
+| GET    | `/api/auth/oidc/callback`             | OIDC callback handler                       |
 
 ### Systems (`/api/systems/*`)
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/systems` | List all systems with update counts |
-| GET | `/api/systems/:id` | System detail with updates and history |
-| POST | `/api/systems` | Add a new system |
-| PUT | `/api/systems/reorder` | Reorder systems |
-| PUT | `/api/systems/:id` | Update system configuration |
-| POST | `/api/systems/test-connection` | Test SSH connectivity |
-| POST | `/api/systems/:id/reboot` | Reboot a system |
-| POST | `/api/systems/:id/revoke-host-key` | Clear the stored trusted host key |
-| DELETE | `/api/systems/:id` | Remove a system |
-| GET | `/api/systems/:id/updates` | Cached updates for a system |
-| GET | `/api/systems/:id/history` | Upgrade history for a system |
+| Method | Endpoint                                           | Description                                                     |
+| ------ | -------------------------------------------------- | --------------------------------------------------------------- |
+| GET    | `/api/systems`                                     | List all systems with update counts                             |
+| GET    | `/api/systems/:id`                                 | System detail with updates and history                          |
+| POST   | `/api/systems`                                     | Add a new system                                                |
+| PUT    | `/api/systems/reorder`                             | Reorder systems                                                 |
+| PUT    | `/api/systems/upgrade-order`                       | Reorder the default Upgrade All system order                    |
+| GET    | `/api/systems/upgrade-groups`                      | List saved Upgrade All groups and the Ungrouped position        |
+| POST   | `/api/systems/upgrade-groups`                      | Create an Upgrade All group                                     |
+| PUT    | `/api/systems/upgrade-groups/reorder`              | Reorder Upgrade All groups and Ungrouped                        |
+| PUT    | `/api/systems/upgrade-groups/systems`              | Move systems between Upgrade All groups and set per-group order |
+| PUT    | `/api/systems/upgrade-groups/:id`                  | Rename an Upgrade All group                                     |
+| DELETE | `/api/systems/upgrade-groups/:id`                  | Delete an Upgrade All group                                     |
+| PUT    | `/api/systems/:id`                                 | Update system configuration                                     |
+| PUT    | `/api/systems/:id/upgrade-mode`                    | Toggle the system's default full-upgrade mode where supported   |
+| PUT    | `/api/systems/:id/upgrade-all-exclusion`           | Include or exclude a system from Upgrade All by default         |
+| POST   | `/api/systems/test-connection`                     | Test SSH connectivity                                           |
+| POST   | `/api/systems/:id/reboot`                          | Reboot a system                                                 |
+| POST   | `/api/systems/:id/revoke-host-key`                 | Clear the stored trusted host key                               |
+| DELETE | `/api/systems/:id`                                 | Remove a system                                                 |
+| GET    | `/api/systems/:id/updates`                         | Cached updates for a system                                     |
+| GET    | `/api/systems/:id/history`                         | Upgrade history for a system                                    |
+| POST   | `/api/systems/:id/hidden-updates`                  | Hide one visible update from counts and dashboards              |
+| DELETE | `/api/systems/:id/hidden-updates/:hiddenUpdateId`  | Unhide an update                                                |
+| POST   | `/api/systems/:id/package-issues/:issueId/dismiss` | Dismiss a visible package-manager issue                         |
 
 ### Updates
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| POST | `/api/systems/:id/check` | Check one system for updates |
-| POST | `/api/systems/:id/cancel` | Request cancellation of the running operation on a system |
-| POST | `/api/systems/check-all` | Check all systems (background) |
-| POST | `/api/systems/:id/upgrade` | Upgrade all packages on a system |
-| POST | `/api/systems/:id/full-upgrade` | Full/dist upgrade on a system |
-| POST | `/api/systems/:id/upgrade-packages` | Upgrade one or more selected visible packages on a system |
-| POST | `/api/systems/:id/upgrade/:packageName` | Upgrade one selected package (compatibility alias) |
-| POST | `/api/cache/refresh` | Invalidate cache and re-check all systems |
-| GET | `/api/jobs/:id` | Poll background job status |
+| Method | Endpoint                                         | Description                                               |
+| ------ | ------------------------------------------------ | --------------------------------------------------------- |
+| POST   | `/api/systems/:id/check`                         | Check one system for updates                              |
+| POST   | `/api/systems/:id/cancel`                        | Request cancellation of the running operation on a system |
+| POST   | `/api/systems/:id/package-issues/:issueId/solve` | Run the repair action for a package-manager issue         |
+| POST   | `/api/systems/check-all`                         | Check all systems (background)                            |
+| POST   | `/api/systems/upgrade-all`                       | Queue an Upgrade All batch for selected systems           |
+| POST   | `/api/systems/:id/upgrade`                       | Upgrade all packages on a system                          |
+| POST   | `/api/systems/:id/full-upgrade`                  | Full/dist upgrade on a system                             |
+| POST   | `/api/systems/:id/upgrade-packages`              | Upgrade one or more selected visible packages on a system |
+| POST   | `/api/systems/:id/upgrade/:packageName`          | Upgrade one selected package (compatibility alias)        |
+| POST   | `/api/cache/refresh`                             | Invalidate cache and re-check all systems                 |
+| GET    | `/api/jobs/:id`                                  | Poll background job status                                |
 
 ### Notifications (`/api/notifications/*`)
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/notifications` | List all notification channels |
-| PUT | `/api/notifications/reorder` | Reorder notification channels |
-| GET | `/api/notifications/:id` | Get a notification channel |
-| POST | `/api/notifications` | Create a notification channel |
-| PUT | `/api/notifications/:id` | Update a notification channel |
-| DELETE | `/api/notifications/:id` | Delete a notification channel |
-| POST | `/api/notifications/:id/telegram/link` | Create a one-time Telegram chat binding link |
-| POST | `/api/notifications/:id/telegram/unlink` | Remove the Telegram chat binding and revoke any generated command token |
-| POST | `/api/notifications/:id/telegram/reissue-command-token` | Rotate the Telegram command token for a linked channel with commands enabled |
-| POST | `/api/notifications/test` | Test a notification config inline (before saving) |
-| POST | `/api/notifications/:id/test` | Send a test notification |
+| Method | Endpoint                                                | Description                                                                  |
+| ------ | ------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| GET    | `/api/notifications`                                    | List all notification channels                                               |
+| PUT    | `/api/notifications/reorder`                            | Reorder notification channels                                                |
+| GET    | `/api/notifications/:id`                                | Get a notification channel                                                   |
+| POST   | `/api/notifications`                                    | Create a notification channel                                                |
+| PUT    | `/api/notifications/:id`                                | Update a notification channel                                                |
+| DELETE | `/api/notifications/:id`                                | Delete a notification channel                                                |
+| POST   | `/api/notifications/:id/telegram/link`                  | Create a one-time Telegram chat binding link                                 |
+| POST   | `/api/notifications/:id/telegram/unlink`                | Remove the Telegram chat binding and revoke any generated command token      |
+| POST   | `/api/notifications/:id/telegram/reissue-command-token` | Rotate the Telegram command token for a linked channel with commands enabled |
+| POST   | `/api/notifications/:id/reset-update-dedupe`            | Reset update notification deduplication for a channel                        |
+| POST   | `/api/notifications/test`                               | Test a notification config inline (before saving)                            |
+| POST   | `/api/notifications/:id/test`                           | Send a test notification                                                     |
 
 ### Schedules (`/api/schedules/*`)
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/schedules` | List all schedules |
-| PUT | `/api/schedules/reorder` | Reorder schedules |
-| GET | `/api/schedules/:id` | Get a schedule |
-| POST | `/api/schedules` | Create a schedule |
-| PUT | `/api/schedules/:id` | Update a schedule |
-| DELETE | `/api/schedules/:id` | Delete a schedule |
+| Method | Endpoint                 | Description        |
+| ------ | ------------------------ | ------------------ |
+| GET    | `/api/schedules`         | List all schedules |
+| PUT    | `/api/schedules/reorder` | Reorder schedules  |
+| GET    | `/api/schedules/:id`     | Get a schedule     |
+| POST   | `/api/schedules`         | Create a schedule  |
+| PUT    | `/api/schedules/:id`     | Update a schedule  |
+| DELETE | `/api/schedules/:id`     | Delete a schedule  |
 
 ### Scripts (`/api/scripts/*`)
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/scripts` | List built-in and custom scripts, package-manager definitions, and placeholder help |
-| POST | `/api/scripts` | Create a custom script |
-| PUT | `/api/scripts/:id` | Update a custom script |
-| DELETE | `/api/scripts/:id` | Delete an unused custom script |
-| POST | `/api/scripts/package-managers` | Create a custom package-manager definition |
-| PUT | `/api/scripts/package-managers/:name` | Update package-manager metadata, parser settings, and custom config entries |
-| DELETE | `/api/scripts/package-managers/:name` | Delete an unused custom package-manager definition |
-| POST | `/api/scripts/validate-parser` | Test custom parser settings against sample command output |
-| POST | `/api/scripts/format` | Format a shell command for display/editing |
+| Method | Endpoint                              | Description                                                                         |
+| ------ | ------------------------------------- | ----------------------------------------------------------------------------------- |
+| GET    | `/api/scripts`                        | List built-in and custom scripts, package-manager definitions, and placeholder help |
+| POST   | `/api/scripts`                        | Create a custom script                                                              |
+| PUT    | `/api/scripts/:id`                    | Update a custom script                                                              |
+| DELETE | `/api/scripts/:id`                    | Delete an unused custom script                                                      |
+| POST   | `/api/scripts/package-managers`       | Create a custom package-manager definition                                          |
+| PUT    | `/api/scripts/package-managers/:name` | Update package-manager metadata, parser settings, and custom config entries         |
+| DELETE | `/api/scripts/package-managers/:name` | Delete an unused custom package-manager definition                                  |
+| POST   | `/api/scripts/validate-parser`        | Test custom parser settings against sample command output                           |
+| POST   | `/api/scripts/format`                 | Format a shell command for display/editing                                          |
 
 ### Credentials (`/api/credentials/*`)
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/credentials` | List saved credentials |
-| PUT | `/api/credentials/reorder` | Reorder credentials |
-| GET | `/api/credentials/:id` | Get a credential with masked secrets |
-| POST | `/api/credentials` | Create a credential |
-| PUT | `/api/credentials/:id` | Update a credential |
-| DELETE | `/api/credentials/:id` | Delete a credential |
+| Method | Endpoint                   | Description                          |
+| ------ | -------------------------- | ------------------------------------ |
+| GET    | `/api/credentials`         | List saved credentials               |
+| PUT    | `/api/credentials/reorder` | Reorder credentials                  |
+| GET    | `/api/credentials/:id`     | Get a credential with masked secrets |
+| POST   | `/api/credentials`         | Create a credential                  |
+| PUT    | `/api/credentials/:id`     | Update a credential                  |
+| DELETE | `/api/credentials/:id`     | Delete a credential                  |
 
 ### Passkeys (`/api/passkeys/*`)
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/passkeys` | List passkeys for the authenticated user |
-| PATCH | `/api/passkeys/:id` | Rename a passkey |
-| DELETE | `/api/passkeys/:id` | Remove a passkey |
+| Method | Endpoint            | Description                              |
+| ------ | ------------------- | ---------------------------------------- |
+| GET    | `/api/passkeys`     | List passkeys for the authenticated user |
+| PATCH  | `/api/passkeys/:id` | Rename a passkey                         |
+| DELETE | `/api/passkeys/:id` | Remove a passkey                         |
 
 ### API Tokens (`/api/tokens/*`)
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/tokens` | List tokens for the authenticated user |
-| POST | `/api/tokens` | Create a new token (name, expiresInDays, readOnly) |
-| PATCH | `/api/tokens/:id` | Rename a token |
-| DELETE | `/api/tokens/:id` | Revoke a token |
+| Method | Endpoint          | Description                                        |
+| ------ | ----------------- | -------------------------------------------------- |
+| GET    | `/api/tokens`     | List tokens for the authenticated user             |
+| POST   | `/api/tokens`     | Create a new token (name, expiresInDays, readOnly) |
+| PATCH  | `/api/tokens/:id` | Rename a token                                     |
+| DELETE | `/api/tokens/:id` | Revoke a token                                     |
 
 ### Dashboard & Settings
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/dashboard/stats` | Summary statistics |
-| GET | `/api/dashboard/systems` | All systems with status metadata |
-| GET | `/api/settings` | Current settings |
-| PUT | `/api/settings` | Update settings |
+| Method | Endpoint                 | Description                      |
+| ------ | ------------------------ | -------------------------------- |
+| GET    | `/api/dashboard/stats`   | Summary statistics               |
+| GET    | `/api/dashboard/systems` | All systems with status metadata |
+| GET    | `/api/settings`          | Current settings                 |
+| PUT    | `/api/settings`          | Update settings                  |
 
 ## Security
 
@@ -1015,19 +1059,19 @@ All upgrade operations (upgrade all, full upgrade, selected packages) run via **
 
 If the SSH connection drops while monitoring, the dashboard shows a warning:
 
-> *SSH connection lost during upgrade. The process may still be running on the remote system.*
+> _SSH connection lost during upgrade. The process may still be running on the remote system._
 
 The upgrade itself continues on the remote host unaffected. Temporary files are cleaned up once the exit code is read.
 
 ### What uses SSH-safe mode
 
-| Operation | SSH-safe |
-|-----------|----------|
-| Upgrade all packages | Yes |
-| Full upgrade (dist upgrade) | Yes |
-| Upgrade selected packages | Yes |
-| Check for updates | No (read-only, safe to retry) |
-| Reboot | No (fire-and-forget) |
+| Operation                   | SSH-safe                      |
+| --------------------------- | ----------------------------- |
+| Upgrade all packages        | Yes                           |
+| Full upgrade (dist upgrade) | Yes                           |
+| Upgrade selected packages   | Yes                           |
+| Check for updates           | No (read-only, safe to retry) |
+| Reboot                      | No (fire-and-forget)          |
 
 The UI marks SSH-safe operations with an **SSH-safe** badge in the activity history.
 

--- a/client/lib/scripts.ts
+++ b/client/lib/scripts.ts
@@ -58,6 +58,19 @@ export interface ScriptUsage {
   operationKey: string;
 }
 
+export interface ScriptOperationProfile {
+  operation: ScriptOperation;
+  label: string;
+  allowedTypes: ScriptType[];
+  purpose: string;
+  stepBehavior: string;
+  outputConsumer: string;
+  parserBehavior: string;
+  exitCodeBehavior: string;
+  relevantPlaceholders: string[];
+  defaultStepBadge: string;
+}
+
 export interface CustomPackageManagerDefinition {
   id: number;
   builtin: boolean;
@@ -79,6 +92,7 @@ export interface ScriptsResponse {
   scripts: ScriptDefinition[];
   packageManagers: CustomPackageManagerDefinition[];
   placeholders: PlaceholderHelpEntry[];
+  operationProfiles?: ScriptOperationProfile[];
 }
 
 export function buildOperationKey(operation: ScriptOperation, pkgManager?: string | null): string {

--- a/client/lib/systems.ts
+++ b/client/lib/systems.ts
@@ -332,6 +332,7 @@ export function useUpgradeGroups() {
 function invalidateUpgradeGroupQueries(qc: ReturnType<typeof useQueryClient>) {
   void qc.invalidateQueries({ queryKey: ["upgrade-groups"] });
   void qc.invalidateQueries({ queryKey: ["systems"] });
+  void qc.invalidateQueries({ queryKey: ["system"] });
   void qc.invalidateQueries({ queryKey: ["dashboard"] });
 }
 

--- a/client/lib/systems.ts
+++ b/client/lib/systems.ts
@@ -6,7 +6,7 @@ import type { HostKeyStatus } from "./host-key-status";
 export interface ActiveOperation {
   type: "check" | "upgrade_all" | "full_upgrade_all" | "upgrade_package" | "reboot" | "package_manager_repair";
   startedAt: string;
-  phase?: "reconnecting" | "rechecking";
+  phase?: "queued" | "reconnecting" | "rechecking";
   packageName?: string;
   packageNames?: string[];
   cancelRequested?: boolean;
@@ -56,6 +56,7 @@ export interface System {
   rebootDismissedUptimeSeconds: number | null;
   rebootDismissedAt: string | null;
   excludeFromUpgradeAll: number;
+  upgradeGroupId: number | null;
   upgradeOrder: number;
   hidden: number;
   needsReboot: number;
@@ -74,6 +75,19 @@ export interface System {
   supportsFullUpgrade?: boolean;
   packageIssueCount?: number;
   scriptOverrides: Record<string, string>;
+}
+
+export interface UpgradeGroup {
+  id: number;
+  name: string;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpgradeGroupConfig {
+  groups: UpgradeGroup[];
+  ungroupedSortOrder: number;
 }
 
 export interface CachedUpdate {
@@ -304,6 +318,77 @@ export function useReorderSystemUpgradeOrder() {
       await qc.invalidateQueries({ queryKey: ["systems"] });
       await qc.invalidateQueries({ queryKey: ["dashboard"] });
     },
+  });
+}
+
+export function useUpgradeGroups() {
+  return useQuery({
+    queryKey: ["upgrade-groups"],
+    queryFn: () =>
+      apiFetch<UpgradeGroupConfig>("/systems/upgrade-groups"),
+  });
+}
+
+function invalidateUpgradeGroupQueries(qc: ReturnType<typeof useQueryClient>) {
+  void qc.invalidateQueries({ queryKey: ["upgrade-groups"] });
+  void qc.invalidateQueries({ queryKey: ["systems"] });
+  void qc.invalidateQueries({ queryKey: ["dashboard"] });
+}
+
+export function useCreateUpgradeGroup() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (name: string) =>
+      apiFetch<{ id: number }>("/systems/upgrade-groups", {
+        method: "POST",
+        body: JSON.stringify({ name }),
+      }),
+    onSuccess: () => invalidateUpgradeGroupQueries(qc),
+  });
+}
+
+export function useUpdateUpgradeGroup() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ groupId, name }: { groupId: number; name: string }) =>
+      apiFetch(`/systems/upgrade-groups/${groupId}`, {
+        method: "PUT",
+        body: JSON.stringify({ name }),
+      }),
+    onSuccess: () => invalidateUpgradeGroupQueries(qc),
+  });
+}
+
+export function useDeleteUpgradeGroup() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (groupId: number) =>
+      apiFetch(`/systems/upgrade-groups/${groupId}`, { method: "DELETE" }),
+    onSuccess: () => invalidateUpgradeGroupQueries(qc),
+  });
+}
+
+export function useReorderUpgradeGroups() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (groupKeys: Array<number | "ungrouped">) =>
+      apiFetch("/systems/upgrade-groups/reorder", {
+        method: "PUT",
+        body: JSON.stringify({ groupKeys }),
+      }),
+    onSuccess: () => invalidateUpgradeGroupQueries(qc),
+  });
+}
+
+export function useUpdateSystemUpgradeGroups() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (items: Array<{ systemId: number; groupId: number | null; upgradeOrder: number }>) =>
+      apiFetch("/systems/upgrade-groups/systems", {
+        method: "PUT",
+        body: JSON.stringify({ items }),
+      }),
+    onSuccess: () => invalidateUpgradeGroupQueries(qc),
   });
 }
 

--- a/client/lib/systems.ts
+++ b/client/lib/systems.ts
@@ -367,7 +367,7 @@ export function useRebootSystem() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: number) =>
-      apiFetch<{ success: boolean; message: string }>(`/systems/${id}/reboot`, { method: "POST" }),
+      apiFetch<{ success: boolean; message: string; blocked?: boolean }>(`/systems/${id}/reboot`, { method: "POST" }),
     onSuccess: async (_data, id) => {
       await qc.invalidateQueries({ queryKey: ["system", id] });
       await qc.invalidateQueries({ queryKey: ["systems"] });

--- a/client/lib/updates.ts
+++ b/client/lib/updates.ts
@@ -104,6 +104,24 @@ export function useUpgradeAll() {
   });
 }
 
+export function useUpgradeAllBatch() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (items: Array<{
+      systemId: number;
+      defaultUpgradeModeOverride?: DefaultUpgradeModeOverride;
+    }>) =>
+      apiFetch<{ status: string; batchId: number }>("/systems/upgrade-all", {
+        method: "POST",
+        body: JSON.stringify({ items }),
+      }),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ["systems"] });
+      await qc.invalidateQueries({ queryKey: ["dashboard"] });
+    },
+  });
+}
+
 export function useFullUpgradeAll() {
   const qc = useQueryClient();
   return useMutation({

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -1,32 +1,41 @@
 import { useState, useEffect, useMemo, useRef } from "react";
 import { Link } from "react-router";
 import Sortable from "sortablejs";
+import type { SortableEvent } from "sortablejs";
 import { Layout } from "../components/Layout";
 import { AgoLabel } from "../components/AgoLabel";
 import { Badge } from "../components/Badge";
 import { Modal } from "../components/Modal";
 import { useDashboardStats, useDashboardSystems } from "../lib/dashboard";
-import { useRefreshCache } from "../lib/updates";
+import { useRefreshCache, useUpgradeAllBatch } from "../lib/updates";
 import {
-  useReorderSystemUpgradeOrder,
+  useCreateUpgradeGroup,
+  useDeleteUpgradeGroup,
+  useReorderUpgradeGroups,
+  useUpdateSystemUpgradeGroups,
   useUpdateSystemUpgradeAllExclusion,
   useUpdateSystemUpgradeMode,
+  useUpdateUpgradeGroup,
+  useUpgradeGroups,
 } from "../lib/systems";
-import type { System } from "../lib/systems";
+import type { System, UpgradeGroup } from "../lib/systems";
 import { useToast } from "../context/ToastContext";
 import { useUpgrade } from "../context/UpgradeContext";
 import { deriveSystemUpdateState, isPostUpgradeRecheck, shouldClearLocalUpgrade } from "../lib/system-status";
 
-function moveSystem<T>(items: T[], fromIndex: number, toIndex: number): T[] {
-  if (fromIndex === toIndex) return items;
+const UNGROUPED_KEY = "ungrouped";
 
-  const nextItems = [...items];
-  const [movedItem] = nextItems.splice(fromIndex, 1);
-  nextItems.splice(toIndex, 0, movedItem);
-  return nextItems;
+function getGroupKey(groupId: number | null | undefined): string {
+  return groupId ? String(groupId) : UNGROUPED_KEY;
 }
 
 function compareUpgradeOrder(a: System, b: System): number {
+  const orderDiff = (a.upgradeOrder ?? 1) - (b.upgradeOrder ?? 1);
+  if (orderDiff !== 0) return orderDiff;
+  return a.name.localeCompare(b.name) || a.id - b.id;
+}
+
+function compareSystemsInGroup(a: System, b: System): number {
   const orderDiff = (a.upgradeOrder ?? 1) - (b.upgradeOrder ?? 1);
   if (orderDiff !== 0) return orderDiff;
   return a.name.localeCompare(b.name) || a.id - b.id;
@@ -131,7 +140,7 @@ function StatCard({ label, value, color }: { label: string; value: number; color
   );
 }
 
-function SystemCard({ system, upgrading, checking }: { system: { id: number; name: string; hostname: string; port: number; osName: string | null; isReachable: number; updateCount: number; securityCount: number; keptBackCount: number; needsReboot?: number; cacheAge: string | null; cacheTimestamp?: string | null; isStale?: boolean; lastCheck: { status: "success" | "warning" | "failed"; error: string | null; startedAt: string; completedAt: string | null } | null; activeOperation?: { type: "check" | "upgrade_all" | "full_upgrade_all" | "upgrade_package" | "reboot" | "package_manager_repair"; startedAt: string; phase?: "reconnecting" | "rechecking"; packageName?: string; packageNames?: string[]; cancelRequested?: boolean } | null }; upgrading: boolean; checking: boolean }) {
+function SystemCard({ system, upgrading, checking }: { system: Pick<System, "id" | "name" | "hostname" | "port" | "osName" | "isReachable" | "updateCount" | "securityCount" | "keptBackCount" | "needsReboot" | "cacheAge" | "cacheTimestamp" | "isStale" | "lastCheck" | "activeOperation">; upgrading: boolean; checking: boolean }) {
   const updateState = deriveSystemUpdateState(system, { upgrading, checking });
   const dotColor = updateState === "check_failed" || updateState === "unreachable"
     ? "bg-red-500"
@@ -210,22 +219,34 @@ function SystemCard({ system, upgrading, checking }: { system: { id: number; nam
 }
 
 export default function Dashboard() {
-  const { upgradeAll, isUpgrading, removeUpgrading, upgradingSystems, upgradingCount } = useUpgrade();
+  const { isUpgrading, removeUpgrading, upgradingSystems, upgradingCount } = useUpgrade();
   const { data: systems, dataUpdatedAt } = useDashboardSystems(upgradingCount > 0);
   const hasActiveOps = systems?.some((s) => s.activeOperation) ?? false;
   const { data: stats } = useDashboardStats(hasActiveOps);
+  const { data: upgradeGroupConfig = { groups: [], ungroupedSortOrder: 1_000_000 } } = useUpgradeGroups();
+  const upgradeGroups = upgradeGroupConfig.groups;
   const refreshCache = useRefreshCache();
-  const reorderSystemUpgradeOrder = useReorderSystemUpgradeOrder();
+  const upgradeAllBatch = useUpgradeAllBatch();
+  const createUpgradeGroup = useCreateUpgradeGroup();
+  const updateUpgradeGroup = useUpdateUpgradeGroup();
+  const deleteUpgradeGroup = useDeleteUpgradeGroup();
+  const reorderUpgradeGroups = useReorderUpgradeGroups();
+  const updateSystemUpgradeGroups = useUpdateSystemUpgradeGroups();
   const updateSystemUpgradeAllExclusion = useUpdateSystemUpgradeAllExclusion();
   const updateSystemUpgradeMode = useUpdateSystemUpgradeMode();
   const { addToast } = useToast();
   const [showUpgradeConfirm, setShowUpgradeConfirm] = useState(false);
+  const [upgradeEditMode, setUpgradeEditMode] = useState(false);
   const [selectedSystemIds, setSelectedSystemIds] = useState<number[]>([]);
   const [fullUpgradeSelections, setFullUpgradeSelections] = useState<Record<number, boolean>>({});
   const [upgradeModalSystems, setUpgradeModalSystems] = useState<System[]>([]);
+  const [renameGroup, setRenameGroup] = useState<{ id: number; name: string } | null>(null);
+  const [deleteGroup, setDeleteGroup] = useState<UpgradeGroup | null>(null);
   const upgradeModalSystemsRef = useRef<System[]>([]);
-  const upgradeListRef = useRef<HTMLUListElement | null>(null);
-  const upgradeSortableRef = useRef<Sortable | null>(null);
+  const groupListRef = useRef<HTMLDivElement | null>(null);
+  const groupSortableRef = useRef<Sortable | null>(null);
+  const systemListRefs = useRef(new Map<string, HTMLUListElement>());
+  const systemSortablesRef = useRef<Sortable[]>([]);
 
   // Sync client-side upgrading state with server's activeOperation.
   // React Query only fires inline mutation callbacks for the last .mutate() call,
@@ -262,99 +283,246 @@ export default function Dashboard() {
     () => [...systemsWithUpdates].sort(compareUpgradeOrder),
     [systemsWithUpdates]
   );
+  const orderedModalCandidateSystems = useMemo(
+    () =>
+      [...(systems ?? [])]
+        .filter((s) => !isUpgrading(s.id) && !hasActiveUpgradeOperation(s))
+        .sort((a, b) => {
+          const groupDiff = (a.upgradeGroupId ?? 1_000_000) - (b.upgradeGroupId ?? 1_000_000);
+          if (groupDiff !== 0) return groupDiff;
+          return compareSystemsInGroup(a, b);
+        }),
+    [systems, isUpgrading]
+  );
   const modalSystems = showUpgradeConfirm ? upgradeModalSystems : orderedSystemsWithUpdates;
+  const visibleModalSystems = upgradeEditMode
+    ? modalSystems
+    : modalSystems.filter((system) => system.updateCount > 0);
   const excludedSystems = orderedSystemsWithUpdates.filter((s) => s.excludeFromUpgradeAll === 1);
   const defaultSelectedSystemIds = orderedSystemsWithUpdates
     .filter((s) => s.excludeFromUpgradeAll !== 1)
     .map((s) => s.id);
-  const selectedSystems = modalSystems.filter((s) => selectedSystemIds.includes(s.id));
+  const selectedSystems = modalSystems.filter((s) => selectedSystemIds.includes(s.id) && s.updateCount > 0);
   const selectedUpdateCount = selectedSystems.reduce((sum, s) => sum + s.updateCount, 0);
+  const groupsById = useMemo(
+    () => new Map(upgradeGroups.map((group) => [group.id, group])),
+    [upgradeGroups]
+  );
+  const orderedGroupsForModal = useMemo(() => {
+    const groups: Array<{ key: string; id: number | null; name: string; sortOrder: number; systems: System[]; realGroup?: UpgradeGroup }> =
+      upgradeGroups
+        .slice()
+        .sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name) || a.id - b.id)
+        .map((group) => ({
+          key: String(group.id),
+          id: group.id,
+          name: group.name,
+          sortOrder: group.sortOrder,
+          systems: visibleModalSystems
+            .filter((system) => system.upgradeGroupId === group.id)
+            .sort(compareSystemsInGroup),
+          realGroup: group,
+        }));
+    const ungroupedSystems = visibleModalSystems
+      .filter((system) => !system.upgradeGroupId || !groupsById.has(system.upgradeGroupId))
+      .sort(compareSystemsInGroup);
+    if (upgradeGroups.length > 0) {
+      groups.push({
+        key: UNGROUPED_KEY,
+        id: null,
+        name: "Ungrouped",
+        sortOrder: upgradeGroupConfig.ungroupedSortOrder,
+        systems: ungroupedSystems,
+      });
+    } else if (ungroupedSystems.length > 0) {
+      groups.push({
+        key: UNGROUPED_KEY,
+        id: null,
+        name: "Systems",
+        sortOrder: 0,
+        systems: ungroupedSystems,
+      });
+    }
+    const sortedGroups = groups.sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name));
+    return upgradeEditMode
+      ? sortedGroups
+      : sortedGroups.filter((group) => group.systems.length > 0);
+  }, [upgradeGroups, upgradeGroupConfig.ungroupedSortOrder, visibleModalSystems, groupsById, upgradeEditMode]);
+  const sortableLayoutKey = useMemo(
+    () =>
+      orderedGroupsForModal
+        .map((group) => `${group.key}:${group.systems.map((system) => system.id).join(",")}`)
+        .join("|"),
+    [orderedGroupsForModal]
+  );
 
   useEffect(() => {
     upgradeModalSystemsRef.current = upgradeModalSystems;
   }, [upgradeModalSystems]);
 
   useEffect(() => {
-    if (!showUpgradeConfirm) return;
+    if (!showUpgradeConfirm || !upgradeEditMode) return;
 
-    const eligibleById = new Map(orderedSystemsWithUpdates.map((system) => [system.id, system]));
+    const systemsById = new Map(orderedModalCandidateSystems.map((system) => [system.id, system]));
     setUpgradeModalSystems((current) => {
       const refreshedSystems = current
-        .map((system) => eligibleById.get(system.id))
+        .map((system) => systemsById.get(system.id))
         .filter((system): system is System => Boolean(system));
       const refreshedIds = new Set(refreshedSystems.map((system) => system.id));
-      const newlyEligibleSystems = orderedSystemsWithUpdates.filter((system) => !refreshedIds.has(system.id));
+      const newlyEligibleSystems = orderedModalCandidateSystems.filter((system) => !refreshedIds.has(system.id));
       return [...refreshedSystems, ...newlyEligibleSystems];
     });
-    setSelectedSystemIds((current) => current.filter((systemId) => eligibleById.has(systemId)));
+    setSelectedSystemIds((current) =>
+      current.filter((systemId) => {
+        const system = systemsById.get(systemId);
+        return !!system && system.updateCount > 0;
+      })
+    );
     setFullUpgradeSelections((current) => {
       const next: Record<number, boolean> = {};
-      for (const system of orderedSystemsWithUpdates) {
+      for (const system of orderedModalCandidateSystems) {
         next[system.id] = current[system.id] ?? isDefaultFullUpgradeEnabled(system);
       }
       return next;
     });
-  }, [showUpgradeConfirm, orderedSystemsWithUpdates]);
+  }, [showUpgradeConfirm, orderedModalCandidateSystems]);
 
-  useEffect(() => {
-    const list = upgradeListRef.current;
-    if (!showUpgradeConfirm || !list || upgradeModalSystems.length <= 1) {
-      upgradeSortableRef.current?.destroy();
-      upgradeSortableRef.current = null;
+  const restoreSortableDomMove = (evt: SortableEvent) => {
+    if (evt.oldIndex === undefined) return;
+
+    const refIndex =
+      evt.from === evt.to &&
+      evt.newIndex !== undefined &&
+      evt.newIndex < evt.oldIndex
+        ? evt.oldIndex + 1
+        : evt.oldIndex;
+    evt.from.insertBefore(evt.item, evt.from.children[refIndex] ?? null);
+  };
+
+  const persistSystemGroupingFromDom = (evt: SortableEvent) => {
+    const root = groupListRef.current;
+    if (!root) {
+      restoreSortableDomMove(evt);
       return;
     }
-
-    upgradeSortableRef.current?.destroy();
-    upgradeSortableRef.current = new Sortable(list, {
-      animation: 150,
-      handle: ".upgrade-drag-handle",
-      ghostClass: "sortable-ghost",
-      chosenClass: "sortable-chosen",
-      onEnd: (evt) => {
-        if (
-          evt.oldIndex === undefined ||
-          evt.newIndex === undefined ||
-          evt.oldIndex === evt.newIndex
-        ) {
-          return;
+    const updates = new Map<number, { groupId: number | null; upgradeOrder: number }>();
+    for (const list of Array.from(root.querySelectorAll<HTMLUListElement>("[data-system-list-group]"))) {
+      const rawGroupId = list.dataset.systemListGroup;
+      const groupId = rawGroupId && rawGroupId !== UNGROUPED_KEY ? Number(rawGroupId) : null;
+      Array.from(list.querySelectorAll<HTMLElement>("[data-system-id]")).forEach((node, index) => {
+        const systemId = Number(node.dataset.systemId);
+        if (Number.isInteger(systemId) && systemId > 0) {
+          updates.set(systemId, { groupId, upgradeOrder: index + 1 });
         }
-
-        const previousSystems = upgradeModalSystemsRef.current;
-        const nextSystems = moveSystem(previousSystems, evt.oldIndex, evt.newIndex);
-
-        setUpgradeModalSystems(nextSystems);
-        reorderSystemUpgradeOrder.mutate(nextSystems.map((system) => system.id), {
-          onError: (err) => {
-            setUpgradeModalSystems(previousSystems);
-            addToast(err.message, "danger");
-          },
-        });
-      },
-    });
-
-    return () => {
-      upgradeSortableRef.current?.destroy();
-      upgradeSortableRef.current = null;
-    };
-  }, [showUpgradeConfirm, upgradeModalSystems.length, reorderSystemUpgradeOrder, addToast]);
+      });
+    }
+    if (updates.size === 0) {
+      restoreSortableDomMove(evt);
+      return;
+    }
+    const payload = Array.from(updates.entries()).map(([systemId, update]) => ({
+      systemId,
+      groupId: update.groupId,
+      upgradeOrder: update.upgradeOrder,
+    }));
+    const previousSystems = upgradeModalSystemsRef.current;
+    restoreSortableDomMove(evt);
+    setUpgradeModalSystems((current) =>
+      current.map((system) => {
+        const update = updates.get(system.id);
+        return update
+          ? { ...system, upgradeGroupId: update.groupId, upgradeOrder: update.upgradeOrder }
+          : system;
+      })
+    );
+    window.setTimeout(() => {
+      updateSystemUpgradeGroups.mutate(payload, {
+        onError: (err) => {
+          setUpgradeModalSystems(previousSystems);
+          addToast(err.message, "danger");
+        },
+      });
+    }, 0);
+  };
 
   useEffect(() => {
-    upgradeSortableRef.current?.option("disabled", reorderSystemUpgradeOrder.isPending);
-  }, [reorderSystemUpgradeOrder.isPending]);
+    systemSortablesRef.current.forEach((sortable) => sortable.destroy());
+    systemSortablesRef.current = [];
+    groupSortableRef.current?.destroy();
+    groupSortableRef.current = null;
+
+    if (!showUpgradeConfirm) return;
+
+    const root = groupListRef.current;
+    if (root && orderedGroupsForModal.length > 1) {
+      groupSortableRef.current = new Sortable(root, {
+        animation: 150,
+        handle: ".upgrade-group-drag-handle",
+        draggable: "[data-upgrade-group-key]",
+        ghostClass: "sortable-ghost",
+        chosenClass: "sortable-chosen",
+        onEnd: (evt) => {
+          const groupKeys = Array.from(root.querySelectorAll<HTMLElement>("[data-upgrade-group-key]"))
+            .map((node) => node.dataset.upgradeGroupKey)
+            .map((key) => key === UNGROUPED_KEY ? UNGROUPED_KEY : Number(key))
+            .filter((key): key is number | typeof UNGROUPED_KEY => key === UNGROUPED_KEY || (Number.isInteger(key) && key > 0));
+          restoreSortableDomMove(evt);
+          if (groupKeys.length === orderedGroupsForModal.length) {
+            window.setTimeout(() => {
+              reorderUpgradeGroups.mutate(groupKeys, {
+                onError: (err) => addToast(err.message, "danger"),
+              });
+            }, 0);
+          }
+        },
+      });
+    }
+
+    for (const [groupKey, list] of systemListRefs.current.entries()) {
+      if (!list) continue;
+      const sortable = new Sortable(list, {
+        animation: 150,
+        group: "upgrade-systems",
+        handle: ".upgrade-drag-handle",
+        ghostClass: "sortable-ghost",
+        chosenClass: "sortable-chosen",
+        onEnd: persistSystemGroupingFromDom,
+      });
+      systemSortablesRef.current.push(sortable);
+      if (!groupKey) sortable.option("disabled", true);
+    }
+
+    return () => {
+      systemSortablesRef.current.forEach((sortable) => sortable.destroy());
+      systemSortablesRef.current = [];
+      groupSortableRef.current?.destroy();
+      groupSortableRef.current = null;
+    };
+  }, [showUpgradeConfirm, upgradeEditMode, sortableLayoutKey, orderedGroupsForModal.length, reorderUpgradeGroups, addToast]);
+
+  useEffect(() => {
+    const disabled = !upgradeEditMode || updateSystemUpgradeGroups.isPending || reorderUpgradeGroups.isPending;
+    systemSortablesRef.current.forEach((sortable) => sortable.option("disabled", disabled));
+    groupSortableRef.current?.option("disabled", disabled);
+  }, [upgradeEditMode, updateSystemUpgradeGroups.isPending, reorderUpgradeGroups.isPending]);
 
   const openUpgradeConfirm = () => {
     setSelectedSystemIds(defaultSelectedSystemIds);
-    setUpgradeModalSystems(orderedSystemsWithUpdates);
+    setUpgradeEditMode(false);
+    setUpgradeModalSystems(orderedModalCandidateSystems);
     setFullUpgradeSelections(Object.fromEntries(
-      orderedSystemsWithUpdates.map((s) => [s.id, isDefaultFullUpgradeEnabled(s)])
+      orderedModalCandidateSystems.map((s) => [s.id, isDefaultFullUpgradeEnabled(s)])
     ));
     setShowUpgradeConfirm(true);
   };
 
   const closeUpgradeConfirm = () => {
     setShowUpgradeConfirm(false);
+    setUpgradeEditMode(false);
     setSelectedSystemIds([]);
     setUpgradeModalSystems([]);
+    setRenameGroup(null);
+    setDeleteGroup(null);
     setFullUpgradeSelections({});
   };
 
@@ -412,36 +580,80 @@ export default function Dashboard() {
     );
   };
 
+  const handleCreateGroup = () => {
+    const existingNames = new Set(upgradeGroups.map((group) => group.name.trim().toLowerCase()));
+    let index = 1;
+    while (existingNames.has(`group ${index}`)) index += 1;
+    const name = `Group ${index}`;
+    createUpgradeGroup.mutate(name, {
+      onError: (err) => addToast(err.message, "danger"),
+    });
+  };
+
+  const openRenameGroup = (group: UpgradeGroup) => {
+    setRenameGroup({ id: group.id, name: group.name });
+  };
+
+  const saveRenameGroup = () => {
+    if (!renameGroup) return;
+    const name = renameGroup.name.trim();
+    const currentGroup = upgradeGroups.find((group) => group.id === renameGroup.id);
+    if (!name || !currentGroup) return;
+    if (name === currentGroup.name) {
+      setRenameGroup(null);
+      return;
+    }
+    updateUpgradeGroup.mutate(
+      { groupId: renameGroup.id, name },
+      {
+        onSuccess: () => setRenameGroup(null),
+        onError: (err) => addToast(err.message, "danger"),
+      }
+    );
+  };
+
+  const handleDeleteGroup = (group: UpgradeGroup) => {
+    setDeleteGroup(group);
+  };
+
+  const confirmDeleteGroup = () => {
+    if (!deleteGroup) return;
+    deleteUpgradeGroup.mutate(deleteGroup.id, {
+      onSuccess: () => setDeleteGroup(null),
+      onError: (err) => addToast(err.message, "danger"),
+    });
+  };
+
   const handleUpgradeAll = () => {
     const latestSystemsById = new Map((systems ?? []).map((system) => [system.id, system]));
     const systemsToUpgrade = modalSystems
       .map((system) => latestSystemsById.get(system.id) ?? system)
       .filter((system) =>
         selectedSystemIds.includes(system.id) &&
+        system.updateCount > 0 &&
         isUpgradeAllEligible(system, isUpgrading(system.id))
       );
     if (systemsToUpgrade.length === 0) return;
 
     const fullUpgradeBySystemId = fullUpgradeSelections;
     closeUpgradeConfirm();
-    for (const s of systemsToUpgrade) {
+    const items = systemsToUpgrade.map((s) => {
       const canOverrideMode = supportsDefaultUpgradeModeOverride(s);
-      const override =
+      const defaultUpgradeModeOverride =
         !canOverrideMode
           ? undefined
-          : {
-              defaultUpgradeModeOverride: fullUpgradeBySystemId[s.id]
+          : fullUpgradeBySystemId[s.id]
                 ? "aggressive" as const
-                : "standard" as const,
+                : "standard" as const;
+      return {
+        systemId: s.id,
+        defaultUpgradeModeOverride,
       };
-      void upgradeAll(s.id, override, {
-        onSuccess: (d: any) => {
-          const toast = getDashboardUpgradeToast(s.name, d.status);
-          addToast(toast.message, toast.type);
-        },
-        onError: (err: Error) => addToast(`${s.name}: ${err.message}`, "danger"),
-      });
-    }
+    });
+    upgradeAllBatch.mutate(items, {
+      onSuccess: () => addToast(`Upgrade All queued for ${items.length} system${items.length !== 1 ? "s" : ""}`, "info"),
+      onError: (err) => addToast(err.message, "danger"),
+    });
   };
 
   return (
@@ -457,22 +669,20 @@ export default function Dashboard() {
           >
             {refreshCache.isPending ? <span className="spinner spinner-sm" /> : "Refresh All"}
           </button>
-          {(systemsWithUpdates.length > 0 || hasUpgradeInProgress) && (
-            <button
-              onClick={openUpgradeConfirm}
-              disabled={hasUpgradeInProgress}
-              className="px-3 py-1.5 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors disabled:opacity-50 whitespace-nowrap"
-            >
-              {hasUpgradeInProgress ? (
-                <span className="flex items-center gap-1.5">
-                  <span className="spinner spinner-sm" />
-                  Upgrading...
-                </span>
-              ) : (
-                "Upgrade All"
-              )}
-            </button>
-          )}
+          <button
+            onClick={openUpgradeConfirm}
+            disabled={hasUpgradeInProgress}
+            className="px-3 py-1.5 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors disabled:opacity-50 whitespace-nowrap"
+          >
+            {hasUpgradeInProgress ? (
+              <span className="flex items-center gap-1.5">
+                <span className="spinner spinner-sm" />
+                Upgrading...
+              </span>
+            ) : (
+              "Upgrade All"
+            )}
+          </button>
         </div>
       }
     >
@@ -519,84 +729,197 @@ export default function Dashboard() {
         <p className="text-sm text-slate-600 dark:text-slate-300 mb-4">
           Apply {selectedUpdateCount} update{selectedUpdateCount !== 1 ? "s" : ""} across {selectedSystems.length} system{selectedSystems.length !== 1 ? "s" : ""}?
         </p>
-        {systemsWithUpdates.length > 0 && (
+        {modalSystems.length > 0 ? (
           <div className="mb-4">
-            <ul ref={upgradeListRef} className="space-y-2">
-              {modalSystems.map((s) => {
-                const isSelected = selectedSystemIds.includes(s.id);
-                const canOverrideMode = supportsDefaultUpgradeModeOverride(s);
-                const fullUpgradeEnabled = fullUpgradeSelections[s.id] ?? false;
-                const fullUpgradeSaving =
-                  updateSystemUpgradeMode.isPending &&
-                  updateSystemUpgradeMode.variables?.systemId === s.id;
-
-                return (
-                  <li
-                    key={s.id}
-                    className={`grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-lg border p-3 sm:grid-cols-[auto_minmax(0,1fr)_auto] ${
-                      isSelected
-                        ? "bg-white dark:bg-slate-800/60"
-                        : "bg-slate-50 dark:bg-slate-700/50"
-                    } border-border`}
-                  >
-                    <span
-                      className={`upgrade-drag-handle shrink-0 rounded-md p-1 text-slate-400 transition-colors ${
-                        reorderSystemUpgradeOrder.isPending || modalSystems.length < 2
-                          ? "cursor-not-allowed opacity-40"
-                          : "cursor-grab hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-700"
-                      }`}
-                      title="Drag to set upgrade order"
-                      aria-label={`Drag to set upgrade order for ${s.name}`}
-                    >
-                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 6h.01M8 12h.01M8 18h.01M16 6h.01M16 12h.01M16 18h.01" />
-                      </svg>
-                    </span>
-                    <div className="flex min-w-0 flex-wrap items-center gap-3">
-                      <input
-                        type="checkbox"
-                        checked={isSelected}
-                        onChange={() => toggleSystemSelection(s.id)}
-                        disabled={updateSystemUpgradeAllExclusion.isPending}
-                        className="shrink-0 rounded"
-                        aria-label={`${isSelected ? "Exclude" : "Include"} ${s.name} in Upgrade All`}
-                      />
-                      <span className="block min-w-0 flex-1 truncate text-sm text-slate-700 dark:text-slate-200">
-                        {s.name}
+            <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <button
+                type="button"
+                role="switch"
+                aria-checked={upgradeEditMode}
+                onClick={() => setUpgradeEditMode((current) => !current)}
+                className="inline-flex w-fit items-center gap-2 rounded-md px-1 py-1 text-xs text-slate-600 transition-colors hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-700"
+              >
+                <span
+                  className={`relative h-5 w-9 rounded-full transition-colors ${
+                    upgradeEditMode ? "bg-blue-500" : "bg-slate-300 dark:bg-slate-600"
+                  }`}
+                  aria-hidden="true"
+                >
+                  <span
+                    className={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white transition-transform ${
+                      upgradeEditMode ? "translate-x-4" : ""
+                    }`}
+                  />
+                </span>
+                Edit mode
+              </button>
+              {upgradeEditMode && (
+                <button
+                  type="button"
+                  onClick={handleCreateGroup}
+                  disabled={createUpgradeGroup.isPending}
+                  className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-50 dark:text-slate-200 dark:hover:bg-slate-700 sm:w-auto"
+                >
+                  Add group
+                </button>
+              )}
+            </div>
+            <div ref={groupListRef} className="space-y-3">
+              {orderedGroupsForModal.length === 0 && (
+                <div className="rounded-lg border border-dashed border-border p-4 text-sm text-slate-500 dark:text-slate-400">
+                  No systems have updates right now. Enable edit mode to organize all systems.
+                </div>
+              )}
+              {orderedGroupsForModal.map((group) => (
+                <section
+                  key={group.key}
+                  data-group-id={group.id ?? undefined}
+                  data-upgrade-group-key={group.key}
+                  data-real-group={group.id ? "true" : "false"}
+                  className="rounded-lg border border-border bg-slate-50/60 p-2 dark:bg-slate-800/40"
+                >
+                  <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span
+                        className={`upgrade-group-drag-handle shrink-0 rounded-md p-1 text-slate-400 transition-colors ${
+                          upgradeEditMode && orderedGroupsForModal.length > 1
+                            ? "cursor-grab hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-700"
+                            : "cursor-default opacity-40"
+                        }`}
+                        title={upgradeEditMode && orderedGroupsForModal.length > 1 ? "Drag to reorder group" : undefined}
+                        aria-label={upgradeEditMode && orderedGroupsForModal.length > 1 ? `Drag to reorder ${group.name}` : undefined}
+                      >
+                        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 6h.01M8 12h.01M8 18h.01M16 6h.01M16 12h.01M16 18h.01" />
+                        </svg>
                       </span>
-                      {canOverrideMode && (
+                      <h3 className="min-w-0 truncate text-sm font-semibold text-slate-700 dark:text-slate-100">
+                        {group.name}
+                      </h3>
+                      <Badge variant="muted" small>{group.systems.length}</Badge>
+                    </div>
+                    {upgradeEditMode && group.realGroup && (
+                      <div className="flex gap-2">
                         <button
                           type="button"
-                          onClick={() => toggleFullUpgradeSelection(s.id)}
-                          disabled={!isSelected || fullUpgradeSaving}
-                          aria-pressed={fullUpgradeEnabled}
-                          className={`shrink-0 rounded-md border px-2.5 py-1 text-xs whitespace-nowrap transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
-                            fullUpgradeEnabled
-                              ? "border-blue-600 bg-blue-600 text-white"
-                              : "border-border bg-white text-slate-600 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800"
-                          }`}
-                          title="Toggle and save full upgrade for this system"
+                          onClick={() => openRenameGroup(group.realGroup!)}
+                          className="rounded p-1.5 transition-colors hover:bg-slate-100 dark:hover:bg-slate-700"
+                          title="Edit group name"
                         >
-                          Full upgrade
+                          <span className="sr-only">Edit group name</span>
+                          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                          </svg>
                         </button>
-                      )}
-                    </div>
-                    <div className="col-start-2 flex min-w-0 flex-wrap items-center gap-2 sm:col-start-auto sm:justify-end">
-                      <Badge variant="warning" small>{s.updateCount} updates</Badge>
-                      {s.securityCount > 0 && (
-                        <Badge variant="danger" small>{s.securityCount} security</Badge>
-                      )}
-                      {s.keptBackCount > 0 && (
-                        <Badge variant="muted" small>{s.keptBackCount} kept back</Badge>
-                      )}
-                    </div>
-                  </li>
-                );
-              })}
-            </ul>
-            {systemsWithUpdates.length > 1 && (
+                        <button
+                          type="button"
+                          onClick={() => handleDeleteGroup(group.realGroup!)}
+                          className="rounded p-1.5 text-red-500 transition-colors hover:bg-red-50 dark:hover:bg-red-900/20"
+                          title="Delete group"
+                        >
+                          <span className="sr-only">Delete group</span>
+                          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                          </svg>
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                  <ul
+                    ref={(node) => {
+                      if (node) {
+                        systemListRefs.current.set(group.key, node);
+                      } else {
+                        systemListRefs.current.delete(group.key);
+                      }
+                    }}
+                    data-system-list-group={group.id ?? UNGROUPED_KEY}
+                    className="min-h-6 space-y-2"
+                  >
+                    {group.systems.map((s) => {
+                      const hasUpdates = s.updateCount > 0;
+                      const isSelected = selectedSystemIds.includes(s.id) && hasUpdates;
+                      const canOverrideMode = supportsDefaultUpgradeModeOverride(s);
+                      const fullUpgradeEnabled = fullUpgradeSelections[s.id] ?? false;
+                      const fullUpgradeSaving =
+                        updateSystemUpgradeMode.isPending &&
+                        updateSystemUpgradeMode.variables?.systemId === s.id;
+
+                      return (
+                        <li
+                          key={s.id}
+                          data-system-id={s.id}
+                          className={`grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-lg border p-3 sm:grid-cols-[auto_minmax(0,1fr)_auto] ${
+                            isSelected
+                              ? "bg-white dark:bg-slate-800/80"
+                              : "bg-slate-50 dark:bg-slate-700/50"
+                          } ${hasUpdates ? "border-border" : "border-dashed border-slate-300 opacity-70 dark:border-slate-600"}`}
+                        >
+                          <span
+                            className={`upgrade-drag-handle shrink-0 rounded-md p-1 text-slate-400 transition-colors ${
+                              upgradeEditMode && !updateSystemUpgradeGroups.isPending
+                                ? "cursor-grab hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-700"
+                                : "cursor-default opacity-40"
+                            }`}
+                            title={upgradeEditMode ? "Drag to set upgrade group and order" : undefined}
+                            aria-label={upgradeEditMode ? `Drag to set upgrade group and order for ${s.name}` : undefined}
+                          >
+                            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 6h.01M8 12h.01M8 18h.01M16 6h.01M16 12h.01M16 18h.01" />
+                            </svg>
+                          </span>
+                          <div className="flex min-w-0 flex-wrap items-center gap-3">
+                            <input
+                              type="checkbox"
+                              checked={isSelected}
+                              onChange={() => hasUpdates && toggleSystemSelection(s.id)}
+                              disabled={!hasUpdates || updateSystemUpgradeAllExclusion.isPending}
+                              className="shrink-0 rounded"
+                              aria-label={`${isSelected ? "Exclude" : "Include"} ${s.name} in Upgrade All`}
+                            />
+                            <span className="block min-w-0 flex-1 truncate text-sm text-slate-700 dark:text-slate-200">
+                              {s.name}
+                            </span>
+                            {canOverrideMode && (
+                              <button
+                                type="button"
+                                onClick={() => toggleFullUpgradeSelection(s.id)}
+                                disabled={fullUpgradeSaving}
+                                aria-pressed={fullUpgradeEnabled}
+                                className={`shrink-0 rounded-md border px-2.5 py-1 text-xs whitespace-nowrap transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+                                  fullUpgradeEnabled
+                                    ? "border-blue-600 bg-blue-600 text-white"
+                                    : "border-border bg-white text-slate-600 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800"
+                                }`}
+                                title="Toggle and save full upgrade for this system"
+                              >
+                                Full upgrade
+                              </button>
+                            )}
+                          </div>
+                          <div className="col-start-2 flex min-w-0 flex-wrap items-center gap-2 sm:col-start-auto sm:justify-end">
+                            {hasUpdates ? (
+                              <Badge variant="warning" small>{s.updateCount} updates</Badge>
+                            ) : (
+                              <Badge variant="muted" small>no updates</Badge>
+                            )}
+                            {s.securityCount > 0 && (
+                              <Badge variant="danger" small>{s.securityCount} security</Badge>
+                            )}
+                            {s.keptBackCount > 0 && (
+                              <Badge variant="muted" small>{s.keptBackCount} kept back</Badge>
+                            )}
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </section>
+              ))}
+            </div>
+            {upgradeEditMode && modalSystems.length > 1 && (
               <p className="text-xs text-slate-500 dark:text-slate-400 mt-3">
-                Drag systems to set the saved upgrade order. Upgrade jobs are started from top to bottom without waiting for earlier systems to finish.
+                Drag groups and systems to set the saved upgrade order. Systems in the same group start together; the next group waits for the previous group to finish.
               </p>
             )}
             {systemsWithUpdates.length > 0 && (
@@ -604,6 +927,10 @@ export default function Dashboard() {
                 Check a system to include it in future Upgrade All runs; uncheck it to exclude it.
               </p>
             )}
+          </div>
+        ) : (
+          <div className="mb-4 rounded-lg border border-dashed border-border p-4 text-sm text-slate-500 dark:text-slate-400">
+            No systems are available to group yet.
           </div>
         )}
         <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
@@ -620,6 +947,77 @@ export default function Dashboard() {
           >
             Upgrade All
           </button>
+        </div>
+      </Modal>
+      <Modal
+        open={!!renameGroup}
+        onClose={() => setRenameGroup(null)}
+        title="Rename Group"
+      >
+        <div className="space-y-4">
+          <label className="block">
+            <span className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-200">
+              Group name
+            </span>
+            <input
+              value={renameGroup?.name ?? ""}
+              onChange={(event) =>
+                setRenameGroup((current) =>
+                  current ? { ...current, name: event.target.value } : current
+                )
+              }
+              onKeyDown={(event) => {
+                if (event.key === "Enter") saveRenameGroup();
+              }}
+              autoFocus
+              className="w-full rounded-lg border border-border bg-white px-3 py-2 text-sm outline-none transition-colors focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:bg-slate-900"
+            />
+          </label>
+          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={() => setRenameGroup(null)}
+              className="w-full rounded-lg border border-border px-4 py-2 text-sm transition-colors hover:bg-slate-50 dark:hover:bg-slate-700 sm:w-auto"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={saveRenameGroup}
+              disabled={!renameGroup?.name.trim() || updateUpgradeGroup.isPending}
+              className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm text-white transition-colors hover:bg-blue-700 disabled:opacity-50 sm:w-auto"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      </Modal>
+      <Modal
+        open={!!deleteGroup}
+        onClose={() => setDeleteGroup(null)}
+        title="Delete Group"
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            Delete {deleteGroup?.name}? Systems in this group will move to Ungrouped.
+          </p>
+          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={() => setDeleteGroup(null)}
+              className="w-full rounded-lg border border-border px-4 py-2 text-sm transition-colors hover:bg-slate-50 dark:hover:bg-slate-700 sm:w-auto"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={confirmDeleteGroup}
+              disabled={deleteUpgradeGroup.isPending}
+              className="w-full rounded-lg bg-red-600 px-4 py-2 text-sm text-white transition-colors hover:bg-red-700 disabled:opacity-50 sm:w-auto"
+            >
+              Delete
+            </button>
+          </div>
         </div>
       </Modal>
     </Layout>

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -49,6 +49,20 @@ function isUpgradeAllEligible(system: System, locallyUpgrading: boolean): boolea
   return system.updateCount > 0 && !locallyUpgrading && !hasActiveUpgradeOperation(system);
 }
 
+export function isUpgradePresetSelected(
+  system: Pick<System, "id">,
+  selectedSystemIds: number[],
+): boolean {
+  return selectedSystemIds.includes(system.id);
+}
+
+export function canToggleUpgradePreset(
+  system: Pick<System, "updateCount">,
+  upgradeEditMode: boolean,
+): boolean {
+  return upgradeEditMode || system.updateCount > 0;
+}
+
 function parseManagerList(value: unknown): string[] {
   if (Array.isArray(value)) {
     return value.filter((entry): entry is string => typeof entry === "string");
@@ -299,7 +313,7 @@ export default function Dashboard() {
     ? modalSystems
     : modalSystems.filter((system) => system.updateCount > 0);
   const excludedSystems = orderedSystemsWithUpdates.filter((s) => s.excludeFromUpgradeAll === 1);
-  const defaultSelectedSystemIds = orderedSystemsWithUpdates
+  const defaultSelectedSystemIds = orderedModalCandidateSystems
     .filter((s) => s.excludeFromUpgradeAll !== 1)
     .map((s) => s.id);
   const selectedSystems = modalSystems.filter((s) => selectedSystemIds.includes(s.id) && s.updateCount > 0);
@@ -375,7 +389,7 @@ export default function Dashboard() {
     setSelectedSystemIds((current) =>
       current.filter((systemId) => {
         const system = systemsById.get(systemId);
-        return !!system && system.updateCount > 0;
+        return !!system;
       })
     );
     setFullUpgradeSelections((current) => {
@@ -838,7 +852,8 @@ export default function Dashboard() {
                   >
                     {group.systems.map((s) => {
                       const hasUpdates = s.updateCount > 0;
-                      const isSelected = selectedSystemIds.includes(s.id) && hasUpdates;
+                      const isSelected = isUpgradePresetSelected(s, selectedSystemIds);
+                      const canTogglePreset = canToggleUpgradePreset(s, upgradeEditMode);
                       const canOverrideMode = supportsDefaultUpgradeModeOverride(s);
                       const fullUpgradeEnabled = fullUpgradeSelections[s.id] ?? false;
                       const fullUpgradeSaving =
@@ -872,8 +887,8 @@ export default function Dashboard() {
                             <input
                               type="checkbox"
                               checked={isSelected}
-                              onChange={() => hasUpdates && toggleSystemSelection(s.id)}
-                              disabled={!hasUpdates || updateSystemUpgradeAllExclusion.isPending}
+                              onChange={() => canTogglePreset && toggleSystemSelection(s.id)}
+                              disabled={!canTogglePreset || updateSystemUpgradeAllExclusion.isPending}
                               className="shrink-0 rounded"
                               aria-label={`${isSelected ? "Exclude" : "Include"} ${s.name} in Upgrade All`}
                             />

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -418,6 +418,8 @@ export default function Dashboard() {
         .join("|"),
     [orderedGroupsForModal]
   );
+  const upgradeSortingDisabled =
+    !upgradeEditMode || updateSystemUpgradeGroups.isPending || reorderUpgradeGroups.isPending;
 
   useEffect(() => {
     upgradeModalSystemsRef.current = upgradeModalSystems;
@@ -522,6 +524,7 @@ export default function Dashboard() {
         animation: 150,
         handle: ".upgrade-group-drag-handle",
         draggable: "[data-upgrade-group-key]",
+        disabled: upgradeSortingDisabled,
         ghostClass: "sortable-ghost",
         chosenClass: "sortable-chosen",
         onEnd: (evt) => {
@@ -541,18 +544,18 @@ export default function Dashboard() {
       });
     }
 
-    for (const [groupKey, list] of systemListRefs.current.entries()) {
+    for (const list of systemListRefs.current.values()) {
       if (!list) continue;
       const sortable = new Sortable(list, {
         animation: 150,
         group: "upgrade-systems",
         handle: ".upgrade-drag-handle",
+        disabled: upgradeSortingDisabled,
         ghostClass: "sortable-ghost",
         chosenClass: "sortable-chosen",
         onEnd: persistSystemGroupingFromDom,
       });
       systemSortablesRef.current.push(sortable);
-      if (!groupKey) sortable.option("disabled", true);
     }
 
     return () => {
@@ -561,13 +564,12 @@ export default function Dashboard() {
       groupSortableRef.current?.destroy();
       groupSortableRef.current = null;
     };
-  }, [showUpgradeConfirm, upgradeEditMode, sortableLayoutKey, orderedGroupsForModal.length, reorderUpgradeGroups, addToast]);
+  }, [showUpgradeConfirm, upgradeSortingDisabled, sortableLayoutKey, orderedGroupsForModal.length, reorderUpgradeGroups, addToast]);
 
   useEffect(() => {
-    const disabled = !upgradeEditMode || updateSystemUpgradeGroups.isPending || reorderUpgradeGroups.isPending;
-    systemSortablesRef.current.forEach((sortable) => sortable.option("disabled", disabled));
-    groupSortableRef.current?.option("disabled", disabled);
-  }, [upgradeEditMode, updateSystemUpgradeGroups.isPending, reorderUpgradeGroups.isPending]);
+    systemSortablesRef.current.forEach((sortable) => sortable.option("disabled", upgradeSortingDisabled));
+    groupSortableRef.current?.option("disabled", upgradeSortingDisabled);
+  }, [upgradeSortingDisabled]);
 
   const openUpgradeConfirm = () => {
     setSelectedSystemIds(defaultSelectedSystemIds);
@@ -845,12 +847,12 @@ export default function Dashboard() {
                     <div className="flex min-w-0 items-center gap-2">
                       <span
                         className={`upgrade-group-drag-handle shrink-0 rounded-md p-1 text-slate-400 transition-colors ${
-                          upgradeEditMode && orderedGroupsForModal.length > 1
+                          !upgradeSortingDisabled && orderedGroupsForModal.length > 1
                             ? "cursor-grab hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-700"
                             : "cursor-default opacity-40"
                         }`}
-                        title={upgradeEditMode && orderedGroupsForModal.length > 1 ? "Drag to reorder group" : undefined}
-                        aria-label={upgradeEditMode && orderedGroupsForModal.length > 1 ? `Drag to reorder ${group.name}` : undefined}
+                        title={!upgradeSortingDisabled && orderedGroupsForModal.length > 1 ? "Drag to reorder group" : undefined}
+                        aria-label={!upgradeSortingDisabled && orderedGroupsForModal.length > 1 ? `Drag to reorder ${group.name}` : undefined}
                       >
                         <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 6h.01M8 12h.01M8 18h.01M16 6h.01M16 12h.01M16 18h.01" />
@@ -917,12 +919,12 @@ export default function Dashboard() {
                         >
                           <span
                             className={`upgrade-drag-handle shrink-0 rounded-md p-1 text-slate-400 transition-colors ${
-                              upgradeEditMode && !updateSystemUpgradeGroups.isPending
+                              !upgradeSortingDisabled
                                 ? "cursor-grab hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-700"
                                 : "cursor-default opacity-40"
                             }`}
-                            title={upgradeEditMode ? "Drag to set upgrade group and order" : undefined}
-                            aria-label={upgradeEditMode ? `Drag to set upgrade group and order for ${s.name}` : undefined}
+                            title={!upgradeSortingDisabled ? "Drag to set upgrade group and order" : undefined}
+                            aria-label={!upgradeSortingDisabled ? `Drag to set upgrade group and order for ${s.name}` : undefined}
                           >
                             <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 6h.01M8 12h.01M8 18h.01M16 6h.01M16 12h.01M16 18h.01" />

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -1,7 +1,6 @@
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo, useRef, type PointerEvent as ReactPointerEvent } from "react";
+import { flushSync } from "react-dom";
 import { Link } from "react-router";
-import Sortable from "sortablejs";
-import type { SortableEvent } from "sortablejs";
 import { Layout } from "../components/Layout";
 import { AgoLabel } from "../components/AgoLabel";
 import { Badge } from "../components/Badge";
@@ -24,9 +23,42 @@ import { useUpgrade } from "../context/UpgradeContext";
 import { deriveSystemUpdateState, isPostUpgradeRecheck, shouldClearLocalUpgrade } from "../lib/system-status";
 
 const UNGROUPED_KEY = "ungrouped";
+type UpgradeSystemPlacement = { groupId: number | null; upgradeOrder: number };
+type DropPosition = "before" | "after" | "end";
+type ModalUpgradeGroup = {
+  key: string;
+  id: number | null;
+  name: string;
+  sortOrder: number;
+  systems: System[];
+  realGroup?: UpgradeGroup;
+};
 
 function getGroupKey(groupId: number | null | undefined): string {
   return groupId ? String(groupId) : UNGROUPED_KEY;
+}
+
+function sameUpgradeSystemPlacement(
+  system: Pick<System, "upgradeGroupId" | "upgradeOrder">,
+  placement: UpgradeSystemPlacement,
+): boolean {
+  return (
+    (system.upgradeGroupId ?? null) === placement.groupId &&
+    system.upgradeOrder === placement.upgradeOrder
+  );
+}
+
+export function applyUpgradeSystemPlacements<T extends Pick<System, "id" | "upgradeGroupId" | "upgradeOrder">>(
+  systems: T[],
+  placements: Map<number, UpgradeSystemPlacement>,
+): T[] {
+  if (placements.size === 0) return systems;
+  return systems.map((system) => {
+    const placement = placements.get(system.id);
+    return placement
+      ? { ...system, upgradeGroupId: placement.groupId, upgradeOrder: placement.upgradeOrder }
+      : system;
+  });
 }
 
 function compareUpgradeOrder(a: System, b: System): number {
@@ -303,13 +335,24 @@ export default function Dashboard() {
   const [selectedSystemIds, setSelectedSystemIds] = useState<number[]>([]);
   const [fullUpgradeSelections, setFullUpgradeSelections] = useState<Record<number, boolean>>({});
   const [upgradeModalSystems, setUpgradeModalSystems] = useState<System[]>([]);
+  const [localGroupOrderKeys, setLocalGroupOrderKeys] = useState<string[] | null>(null);
   const [renameGroup, setRenameGroup] = useState<{ id: number; name: string } | null>(null);
   const [deleteGroup, setDeleteGroup] = useState<UpgradeGroup | null>(null);
+  const upgradeGroupContainerRef = useRef<HTMLDivElement | null>(null);
   const upgradeModalSystemsRef = useRef<System[]>([]);
-  const groupListRef = useRef<HTMLDivElement | null>(null);
-  const groupSortableRef = useRef<Sortable | null>(null);
-  const systemListRefs = useRef(new Map<string, HTMLUListElement>());
-  const systemSortablesRef = useRef<Sortable[]>([]);
+  const orderedGroupsForModalRef = useRef<ModalUpgradeGroup[]>([]);
+  const pendingSystemPlacementsRef = useRef<Map<number, UpgradeSystemPlacement>>(new Map());
+  const draggedSystemIdRef = useRef<number | null>(null);
+  const draggedGroupKeyRef = useRef<string | null>(null);
+  const dragPreviewRef = useRef<HTMLElement | null>(null);
+  const dragPreviewOffsetRef = useRef({ x: 0, y: 0 });
+  const dragPreviewCleanupRef = useRef<(() => void) | null>(null);
+  const dragInitialModalSystemsRef = useRef<System[]>([]);
+  const dragSystemPlacementsRef = useRef<Map<number, UpgradeSystemPlacement> | null>(null);
+  const dragSystemLayoutKeyRef = useRef<string>("");
+  const dragInitialGroupKeysRef = useRef<string[]>([]);
+  const dragGroupKeysRef = useRef<string[] | null>(null);
+  const dragDocumentStylesRef = useRef<{ userSelect: string; touchAction: string; overscrollBehavior: string } | null>(null);
 
   // Sync client-side upgrading state with server's activeOperation.
   // React Query only fires inline mutation callbacks for the last .mutate() call,
@@ -372,7 +415,7 @@ export default function Dashboard() {
     [upgradeGroups]
   );
   const orderedGroupsForModal = useMemo(() => {
-    const groups: Array<{ key: string; id: number | null; name: string; sortOrder: number; systems: System[]; realGroup?: UpgradeGroup }> =
+    const groups: ModalUpgradeGroup[] =
       upgradeGroups
         .slice()
         .sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name) || a.id - b.id)
@@ -406,18 +449,19 @@ export default function Dashboard() {
         systems: ungroupedSystems,
       });
     }
-    const sortedGroups = groups.sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name));
+    let sortedGroups = groups.sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name));
+    if (localGroupOrderKeys) {
+      const orderByKey = new Map(localGroupOrderKeys.map((key, index) => [key, index]));
+      sortedGroups = sortedGroups.sort((a, b) => {
+        const aOrder = orderByKey.get(a.key) ?? Number.MAX_SAFE_INTEGER;
+        const bOrder = orderByKey.get(b.key) ?? Number.MAX_SAFE_INTEGER;
+        return aOrder - bOrder || a.sortOrder - b.sortOrder || a.name.localeCompare(b.name);
+      });
+    }
     return upgradeEditMode
       ? sortedGroups
       : sortedGroups.filter((group) => group.systems.length > 0);
-  }, [upgradeGroups, upgradeGroupConfig.ungroupedSortOrder, visibleModalSystems, groupsById, upgradeEditMode]);
-  const sortableLayoutKey = useMemo(
-    () =>
-      orderedGroupsForModal
-        .map((group) => `${group.key}:${group.systems.map((system) => system.id).join(",")}`)
-        .join("|"),
-    [orderedGroupsForModal]
-  );
+  }, [upgradeGroups, upgradeGroupConfig.ungroupedSortOrder, visibleModalSystems, groupsById, upgradeEditMode, localGroupOrderKeys]);
   const upgradeSortingDisabled =
     !upgradeEditMode || updateSystemUpgradeGroups.isPending || reorderUpgradeGroups.isPending;
 
@@ -426,16 +470,29 @@ export default function Dashboard() {
   }, [upgradeModalSystems]);
 
   useEffect(() => {
+    orderedGroupsForModalRef.current = orderedGroupsForModal;
+  }, [orderedGroupsForModal]);
+
+  useEffect(() => {
     if (!showUpgradeConfirm || !upgradeEditMode) return;
 
     const systemsById = new Map(orderedModalCandidateSystems.map((system) => [system.id, system]));
+    for (const [systemId, placement] of pendingSystemPlacementsRef.current) {
+      const refreshedSystem = systemsById.get(systemId);
+      if (refreshedSystem && sameUpgradeSystemPlacement(refreshedSystem, placement)) {
+        pendingSystemPlacementsRef.current.delete(systemId);
+      }
+    }
     setUpgradeModalSystems((current) => {
       const refreshedSystems = current
         .map((system) => systemsById.get(system.id))
         .filter((system): system is System => Boolean(system));
       const refreshedIds = new Set(refreshedSystems.map((system) => system.id));
       const newlyEligibleSystems = orderedModalCandidateSystems.filter((system) => !refreshedIds.has(system.id));
-      return [...refreshedSystems, ...newlyEligibleSystems];
+      return applyUpgradeSystemPlacements(
+        [...refreshedSystems, ...newlyEligibleSystems],
+        pendingSystemPlacementsRef.current,
+      );
     });
     setSelectedSystemIds((current) =>
       current.filter((systemId) => {
@@ -450,128 +507,410 @@ export default function Dashboard() {
       }
       return next;
     });
-  }, [showUpgradeConfirm, orderedModalCandidateSystems]);
+  }, [showUpgradeConfirm, upgradeEditMode, orderedModalCandidateSystems]);
 
-  const restoreSortableDomMove = (evt: SortableEvent) => {
-    if (evt.oldIndex === undefined) return;
-
-    const refIndex =
-      evt.from === evt.to &&
-      evt.newIndex !== undefined &&
-      evt.newIndex < evt.oldIndex
-        ? evt.oldIndex + 1
-        : evt.oldIndex;
-    evt.from.insertBefore(evt.item, evt.from.children[refIndex] ?? null);
-  };
-
-  const persistSystemGroupingFromDom = (evt: SortableEvent) => {
-    const root = groupListRef.current;
-    if (!root) {
-      restoreSortableDomMove(evt);
-      return;
-    }
-    const updates = new Map<number, { groupId: number | null; upgradeOrder: number }>();
-    for (const list of Array.from(root.querySelectorAll<HTMLUListElement>("[data-system-list-group]"))) {
-      const rawGroupId = list.dataset.systemListGroup;
-      const groupId = rawGroupId && rawGroupId !== UNGROUPED_KEY ? Number(rawGroupId) : null;
-      Array.from(list.querySelectorAll<HTMLElement>("[data-system-id]")).forEach((node, index) => {
-        const systemId = Number(node.dataset.systemId);
-        if (Number.isInteger(systemId) && systemId > 0) {
-          updates.set(systemId, { groupId, upgradeOrder: index + 1 });
-        }
-      });
-    }
-    if (updates.size === 0) {
-      restoreSortableDomMove(evt);
-      return;
-    }
+  const persistSystemPlacements = (
+    updates: Map<number, UpgradeSystemPlacement>,
+    previousSystems = upgradeModalSystemsRef.current,
+  ) => {
     const payload = Array.from(updates.entries()).map(([systemId, update]) => ({
       systemId,
       groupId: update.groupId,
       upgradeOrder: update.upgradeOrder,
     }));
-    const previousSystems = upgradeModalSystemsRef.current;
-    restoreSortableDomMove(evt);
-    setUpgradeModalSystems((current) =>
-      current.map((system) => {
-        const update = updates.get(system.id);
-        return update
-          ? { ...system, upgradeGroupId: update.groupId, upgradeOrder: update.upgradeOrder }
-          : system;
-      })
-    );
-    window.setTimeout(() => {
-      updateSystemUpgradeGroups.mutate(payload, {
-        onError: (err) => {
-          setUpgradeModalSystems(previousSystems);
-          addToast(err.message, "danger");
-        },
-      });
-    }, 0);
+    const previousSystemsById = new Map(previousSystems.map((system) => [system.id, system]));
+    const hasChanges = payload.some((update) => {
+      const system = previousSystemsById.get(update.systemId);
+      return system
+        ? (system.upgradeGroupId ?? null) !== update.groupId || system.upgradeOrder !== update.upgradeOrder
+        : false;
+    });
+    if (!hasChanges) return;
+
+    pendingSystemPlacementsRef.current = updates;
+    setUpgradeModalSystems((current) => applyUpgradeSystemPlacements(current, updates));
+    updateSystemUpgradeGroups.mutate(payload, {
+      onError: (err) => {
+        pendingSystemPlacementsRef.current = new Map();
+        setUpgradeModalSystems(previousSystems);
+        addToast(err.message, "danger");
+      },
+    });
   };
 
-  useEffect(() => {
-    systemSortablesRef.current.forEach((sortable) => sortable.destroy());
-    systemSortablesRef.current = [];
-    groupSortableRef.current?.destroy();
-    groupSortableRef.current = null;
+  const getDragLayoutKey = (element: HTMLElement): string | null => {
+    if (element.dataset.systemId) return `system:${element.dataset.systemId}`;
+    if (element.dataset.upgradeGroupKey) return `group:${element.dataset.upgradeGroupKey}`;
+    return null;
+  };
 
-    if (!showUpgradeConfirm) return;
+  const captureDragLayout = (): Map<string, DOMRect> => {
+    const root = upgradeGroupContainerRef.current;
+    const rects = new Map<string, DOMRect>();
+    if (!root) return rects;
 
-    const root = groupListRef.current;
-    if (root && orderedGroupsForModal.length > 1) {
-      groupSortableRef.current = new Sortable(root, {
-        animation: 150,
-        handle: ".upgrade-group-drag-handle",
-        draggable: "[data-upgrade-group-key]",
-        disabled: upgradeSortingDisabled,
-        ghostClass: "sortable-ghost",
-        chosenClass: "sortable-chosen",
-        onEnd: (evt) => {
-          const groupKeys = Array.from(root.querySelectorAll<HTMLElement>("[data-upgrade-group-key]"))
-            .map((node) => node.dataset.upgradeGroupKey)
-            .map((key) => key === UNGROUPED_KEY ? UNGROUPED_KEY : Number(key))
-            .filter((key): key is number | typeof UNGROUPED_KEY => key === UNGROUPED_KEY || (Number.isInteger(key) && key > 0));
-          restoreSortableDomMove(evt);
-          if (groupKeys.length === orderedGroupsForModal.length) {
-            window.setTimeout(() => {
-              reorderUpgradeGroups.mutate(groupKeys, {
-                onError: (err) => addToast(err.message, "danger"),
-              });
-            }, 0);
-          }
-        },
-      });
+    for (const element of Array.from(root.querySelectorAll<HTMLElement>("[data-upgrade-group-key], [data-system-id]"))) {
+      const key = getDragLayoutKey(element);
+      if (key) rects.set(key, element.getBoundingClientRect());
+    }
+    return rects;
+  };
+
+  const animateDragLayoutFrom = (previousRects: Map<string, DOMRect>) => {
+    if (previousRects.size === 0) return;
+
+    const root = upgradeGroupContainerRef.current;
+    if (!root) return;
+
+    const animatedElements: HTMLElement[] = [];
+    for (const element of Array.from(root.querySelectorAll<HTMLElement>("[data-upgrade-group-key], [data-system-id]"))) {
+      const key = getDragLayoutKey(element);
+      const previousRect = key ? previousRects.get(key) : undefined;
+      if (!previousRect) continue;
+
+      const nextRect = element.getBoundingClientRect();
+      const deltaX = previousRect.left - nextRect.left;
+      const deltaY = previousRect.top - nextRect.top;
+      if (Math.abs(deltaX) < 1 && Math.abs(deltaY) < 1) continue;
+
+      element.style.transition = "none";
+      element.style.transform = `translate3d(${deltaX}px, ${deltaY}px, 0)`;
+      element.style.willChange = "transform";
+      animatedElements.push(element);
     }
 
-    for (const list of systemListRefs.current.values()) {
-      if (!list) continue;
-      const sortable = new Sortable(list, {
-        animation: 150,
-        group: "upgrade-systems",
-        handle: ".upgrade-drag-handle",
-        disabled: upgradeSortingDisabled,
-        ghostClass: "sortable-ghost",
-        chosenClass: "sortable-chosen",
-        onEnd: persistSystemGroupingFromDom,
-      });
-      systemSortablesRef.current.push(sortable);
-    }
+    if (animatedElements.length === 0) return;
+    document.body.offsetHeight;
+    window.requestAnimationFrame(() => {
+      for (const element of animatedElements) {
+        element.style.transition = "transform 150ms ease-out";
+        element.style.transform = "";
+      }
+      window.setTimeout(() => {
+        for (const element of animatedElements) {
+          element.style.transition = "";
+          element.style.transform = "";
+          element.style.willChange = "";
+        }
+      }, 180);
+    });
+  };
 
-    return () => {
-      systemSortablesRef.current.forEach((sortable) => sortable.destroy());
-      systemSortablesRef.current = [];
-      groupSortableRef.current?.destroy();
-      groupSortableRef.current = null;
+  const clearDragPreview = () => {
+    dragPreviewCleanupRef.current?.();
+    dragPreviewCleanupRef.current = null;
+    dragPreviewRef.current?.remove();
+    dragPreviewRef.current = null;
+  };
+
+  const lockPointerDragDocument = () => {
+    if (dragDocumentStylesRef.current) return;
+    dragDocumentStylesRef.current = {
+      userSelect: document.body.style.userSelect,
+      touchAction: document.body.style.touchAction,
+      overscrollBehavior: document.body.style.overscrollBehavior,
     };
-  }, [showUpgradeConfirm, upgradeSortingDisabled, sortableLayoutKey, orderedGroupsForModal.length, reorderUpgradeGroups, addToast]);
+    document.body.style.userSelect = "none";
+    document.body.style.touchAction = "none";
+    document.body.style.overscrollBehavior = "contain";
+  };
 
-  useEffect(() => {
-    systemSortablesRef.current.forEach((sortable) => sortable.option("disabled", upgradeSortingDisabled));
-    groupSortableRef.current?.option("disabled", upgradeSortingDisabled);
-  }, [upgradeSortingDisabled]);
+  const unlockPointerDragDocument = () => {
+    const previousStyles = dragDocumentStylesRef.current;
+    if (!previousStyles) return;
+    document.body.style.userSelect = previousStyles.userSelect;
+    document.body.style.touchAction = previousStyles.touchAction;
+    document.body.style.overscrollBehavior = previousStyles.overscrollBehavior;
+    dragDocumentStylesRef.current = null;
+  };
+
+  const moveDragPreview = (clientX: number, clientY: number) => {
+    if (!dragPreviewRef.current || (clientX === 0 && clientY === 0)) return;
+    const { x, y } = dragPreviewOffsetRef.current;
+    dragPreviewRef.current.style.transform = `translate3d(${clientX - x}px, ${clientY - y}px, 0)`;
+  };
+
+  const setPointerDragPreview = (event: ReactPointerEvent<HTMLElement>, source: HTMLElement | null) => {
+    clearDragPreview();
+    if (!source) return;
+
+    const rect = source.getBoundingClientRect();
+    const preview = source.cloneNode(true) as HTMLElement;
+    preview.removeAttribute("id");
+    preview.setAttribute("aria-hidden", "true");
+    preview.style.position = "fixed";
+    preview.style.left = "0";
+    preview.style.top = "0";
+    preview.style.width = `${rect.width}px`;
+    preview.style.pointerEvents = "none";
+    preview.style.zIndex = "9999";
+    preview.style.opacity = "0.94";
+    preview.style.boxShadow = "0 18px 45px rgba(15, 23, 42, 0.35)";
+    preview.style.willChange = "transform";
+    document.body.appendChild(preview);
+    dragPreviewRef.current = preview;
+    dragPreviewOffsetRef.current = {
+      x: Math.max(0, Math.min(rect.width, event.clientX - rect.left)),
+      y: Math.max(0, Math.min(rect.height, event.clientY - rect.top)),
+    };
+    moveDragPreview(event.clientX, event.clientY);
+  };
+
+  const getSystemDropTarget = (
+    clientX: number,
+    clientY: number,
+  ): { groupKey: string; systemId: number | null; position: DropPosition } | null => {
+    const target = document.elementFromPoint(clientX, clientY);
+    if (!(target instanceof HTMLElement)) return null;
+
+    const row = target.closest<HTMLElement>("[data-system-id]");
+    if (row) {
+      const list = row.closest<HTMLElement>("[data-system-list-group]");
+      const groupKey = list?.dataset.systemListGroup;
+      const systemId = Number(row.dataset.systemId);
+      if (groupKey && Number.isInteger(systemId) && systemId > 0) {
+        const rect = row.getBoundingClientRect();
+        return {
+          groupKey,
+          systemId,
+          position: clientY > rect.top + rect.height / 2 ? "after" : "before",
+        };
+      }
+    }
+
+    const list = target.closest<HTMLElement>("[data-system-list-group]");
+    if (list?.dataset.systemListGroup) {
+      return { groupKey: list.dataset.systemListGroup, systemId: null, position: "end" };
+    }
+
+    const group = target.closest<HTMLElement>("[data-upgrade-group-key]");
+    if (group?.dataset.upgradeGroupKey) {
+      return { groupKey: group.dataset.upgradeGroupKey, systemId: null, position: "end" };
+    }
+
+    return null;
+  };
+
+  const getSystemPlacementsForMove = (
+    targetGroupKey: string,
+    targetSystemId: number | null,
+    position: DropPosition,
+  ): Map<number, UpgradeSystemPlacement> | null => {
+    const draggedSystemId = draggedSystemIdRef.current;
+    if (!draggedSystemId || upgradeSortingDisabled) return null;
+    if (targetSystemId === draggedSystemId) return null;
+
+    const groups = orderedGroupsForModalRef.current;
+    const groupsByKey = new Map(groups.map((group) => [group.key, group]));
+    if (!groupsByKey.has(targetGroupKey)) return null;
+
+    const systemIdsByGroup = new Map(
+      groups.map((group) => [
+        group.key,
+        group.systems.map((system) => system.id).filter((systemId) => systemId !== draggedSystemId),
+      ]),
+    );
+    const targetSystemIds = systemIdsByGroup.get(targetGroupKey);
+    if (!targetSystemIds) return null;
+
+    let insertIndex = targetSystemIds.length;
+    if (targetSystemId !== null && position !== "end") {
+      const targetIndex = targetSystemIds.indexOf(targetSystemId);
+      if (targetIndex >= 0) {
+        insertIndex = targetIndex + (position === "after" ? 1 : 0);
+      }
+    }
+    targetSystemIds.splice(Math.min(insertIndex, targetSystemIds.length), 0, draggedSystemId);
+
+    const updates = new Map<number, UpgradeSystemPlacement>();
+    for (const group of groups) {
+      const groupSystemIds = systemIdsByGroup.get(group.key) ?? [];
+      for (const [index, systemId] of groupSystemIds.entries()) {
+        updates.set(systemId, { groupId: group.id, upgradeOrder: index + 1 });
+      }
+    }
+    return updates;
+  };
+
+  const getSystemLayoutKey = (placements: Map<number, UpgradeSystemPlacement>): string =>
+    Array.from(placements.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([systemId, placement]) => `${systemId}:${placement.groupId ?? UNGROUPED_KEY}:${placement.upgradeOrder}`)
+      .join("|");
+
+  const moveDraggedSystemPreview = (clientX: number, clientY: number) => {
+    const target = getSystemDropTarget(clientX, clientY);
+    if (!target) return;
+    const placements = getSystemPlacementsForMove(target.groupKey, target.systemId, target.position);
+    if (!placements) return;
+
+    const layoutKey = getSystemLayoutKey(placements);
+    if (layoutKey === dragSystemLayoutKeyRef.current) return;
+
+    const previousRects = captureDragLayout();
+    dragSystemLayoutKeyRef.current = layoutKey;
+    dragSystemPlacementsRef.current = placements;
+    flushSync(() => {
+      setUpgradeModalSystems((current) => applyUpgradeSystemPlacements(current, placements));
+    });
+    animateDragLayoutFrom(previousRects);
+  };
+
+  const getGroupDropTarget = (clientX: number, clientY: number): { groupKey: string; position: Exclude<DropPosition, "end"> } | null => {
+    const target = document.elementFromPoint(clientX, clientY);
+    if (!(target instanceof HTMLElement)) return null;
+    const group = target.closest<HTMLElement>("[data-upgrade-group-key]");
+    const groupKey = group?.dataset.upgradeGroupKey;
+    if (!group || !groupKey) return null;
+    const rect = group.getBoundingClientRect();
+    return { groupKey, position: clientY > rect.top + rect.height / 2 ? "after" : "before" };
+  };
+
+  const moveDraggedGroupPreview = (clientX: number, clientY: number) => {
+    const draggedGroupKey = draggedGroupKeyRef.current;
+    if (!draggedGroupKey || upgradeSortingDisabled) return;
+
+    const target = getGroupDropTarget(clientX, clientY);
+    if (!target || target.groupKey === draggedGroupKey) return;
+
+    const currentKeys = dragGroupKeysRef.current ?? orderedGroupsForModalRef.current.map((group) => group.key);
+    const groupKeys = currentKeys.filter((key) => key !== draggedGroupKey);
+    const targetIndex = groupKeys.indexOf(target.groupKey);
+    if (targetIndex < 0) return;
+
+    const insertIndex = target.position === "after" ? targetIndex + 1 : targetIndex;
+    groupKeys.splice(insertIndex, 0, draggedGroupKey);
+    if (groupKeys.join("|") === currentKeys.join("|")) return;
+
+    const previousRects = captureDragLayout();
+    dragGroupKeysRef.current = groupKeys;
+    flushSync(() => {
+      setLocalGroupOrderKeys(groupKeys);
+    });
+    animateDragLayoutFrom(previousRects);
+  };
+
+  const finishPointerDrag = () => {
+    const systemPlacements = dragSystemPlacementsRef.current;
+    const groupKeys = dragGroupKeysRef.current;
+    const initialGroupKeys = dragInitialGroupKeysRef.current;
+    const initialModalSystems = dragInitialModalSystemsRef.current;
+
+    clearDragPreview();
+    unlockPointerDragDocument();
+    dragPreviewCleanupRef.current?.();
+    dragPreviewCleanupRef.current = null;
+
+    if (systemPlacements) {
+      persistSystemPlacements(systemPlacements, initialModalSystems);
+    }
+
+    if (groupKeys && groupKeys.join("|") !== initialGroupKeys.join("|")) {
+      const payload = groupKeys
+        .map((key) => key === UNGROUPED_KEY ? UNGROUPED_KEY : Number(key))
+        .filter((key): key is number | typeof UNGROUPED_KEY => key === UNGROUPED_KEY || (Number.isInteger(key) && key > 0));
+      if (payload.length === orderedGroupsForModalRef.current.length) {
+        reorderUpgradeGroups.mutate(payload, {
+          onError: (err) => {
+            setLocalGroupOrderKeys(initialGroupKeys);
+            addToast(err.message, "danger");
+          },
+        });
+      }
+    }
+
+    draggedSystemIdRef.current = null;
+    draggedGroupKeyRef.current = null;
+    dragSystemPlacementsRef.current = null;
+    dragSystemLayoutKeyRef.current = "";
+    dragGroupKeysRef.current = null;
+    dragInitialGroupKeysRef.current = [];
+    dragInitialModalSystemsRef.current = [];
+  };
+
+  const cancelPointerDrag = () => {
+    const initialSystems = dragInitialModalSystemsRef.current;
+    if (dragSystemPlacementsRef.current && initialSystems.length > 0) {
+      setUpgradeModalSystems(initialSystems);
+    }
+    if (dragGroupKeysRef.current) {
+      setLocalGroupOrderKeys(dragInitialGroupKeysRef.current.length > 0 ? dragInitialGroupKeysRef.current : null);
+    }
+    clearDragPreview();
+    unlockPointerDragDocument();
+    draggedSystemIdRef.current = null;
+    draggedGroupKeyRef.current = null;
+    dragSystemPlacementsRef.current = null;
+    dragSystemLayoutKeyRef.current = "";
+    dragGroupKeysRef.current = null;
+    dragInitialGroupKeysRef.current = [];
+    dragInitialModalSystemsRef.current = [];
+  };
+
+  const startPointerDrag = (
+    event: ReactPointerEvent<HTMLElement>,
+    source: HTMLElement | null,
+    onMove: (clientX: number, clientY: number) => void,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    lockPointerDragDocument();
+    setPointerDragPreview(event, source);
+
+    const handlePointerMove = (pointerEvent: PointerEvent) => {
+      pointerEvent.preventDefault();
+      moveDragPreview(pointerEvent.clientX, pointerEvent.clientY);
+      onMove(pointerEvent.clientX, pointerEvent.clientY);
+    };
+    const handlePointerUp = (pointerEvent: PointerEvent) => {
+      pointerEvent.preventDefault();
+      cleanupPointerListeners();
+      finishPointerDrag();
+    };
+    const handlePointerCancel = () => {
+      cleanupPointerListeners();
+      cancelPointerDrag();
+    };
+    const cleanupPointerListeners = () => {
+      document.removeEventListener("pointermove", handlePointerMove, true);
+      document.removeEventListener("pointerup", handlePointerUp, true);
+      document.removeEventListener("pointercancel", handlePointerCancel, true);
+    };
+
+    document.addEventListener("pointermove", handlePointerMove, true);
+    document.addEventListener("pointerup", handlePointerUp, true);
+    document.addEventListener("pointercancel", handlePointerCancel, true);
+    dragPreviewCleanupRef.current = cleanupPointerListeners;
+  };
+
+  const handleSystemPointerDown = (event: ReactPointerEvent<HTMLElement>, systemId: number) => {
+    if (upgradeSortingDisabled) return;
+    draggedSystemIdRef.current = systemId;
+    dragInitialModalSystemsRef.current = upgradeModalSystemsRef.current;
+    dragSystemPlacementsRef.current = null;
+    dragSystemLayoutKeyRef.current = "";
+    startPointerDrag(event, event.currentTarget.closest("li"), moveDraggedSystemPreview);
+  };
+
+  const handleGroupPointerDown = (event: ReactPointerEvent<HTMLElement>, groupKey: string) => {
+    if (upgradeSortingDisabled || orderedGroupsForModal.length <= 1) return;
+    draggedGroupKeyRef.current = groupKey;
+    const groupKeys = orderedGroupsForModalRef.current.map((group) => group.key);
+    dragInitialGroupKeysRef.current = groupKeys;
+    dragGroupKeysRef.current = groupKeys;
+    startPointerDrag(event, event.currentTarget.closest("section"), moveDraggedGroupPreview);
+  };
 
   const openUpgradeConfirm = () => {
+    clearDragPreview();
+    unlockPointerDragDocument();
+    pendingSystemPlacementsRef.current = new Map();
+    draggedSystemIdRef.current = null;
+    draggedGroupKeyRef.current = null;
+    dragSystemPlacementsRef.current = null;
+    dragGroupKeysRef.current = null;
+    setLocalGroupOrderKeys(null);
     setSelectedSystemIds(defaultSelectedSystemIds);
     setUpgradeEditMode(false);
     setUpgradeModalSystems(orderedModalCandidateSystems);
@@ -582,6 +921,14 @@ export default function Dashboard() {
   };
 
   const closeUpgradeConfirm = () => {
+    clearDragPreview();
+    unlockPointerDragDocument();
+    pendingSystemPlacementsRef.current = new Map();
+    draggedSystemIdRef.current = null;
+    draggedGroupKeyRef.current = null;
+    dragSystemPlacementsRef.current = null;
+    dragGroupKeysRef.current = null;
+    setLocalGroupOrderKeys(null);
     setShowUpgradeConfirm(false);
     setUpgradeEditMode(false);
     setSelectedSystemIds([]);
@@ -829,7 +1176,7 @@ export default function Dashboard() {
                 </button>
               )}
             </div>
-            <div ref={groupListRef} className="space-y-3">
+            <div ref={upgradeGroupContainerRef} className="space-y-3">
               {orderedGroupsForModal.length === 0 && (
                 <div className="rounded-lg border border-dashed border-border p-4 text-sm text-slate-500 dark:text-slate-400">
                   No systems have updates right now. Enable edit mode to organize all systems.
@@ -853,6 +1200,8 @@ export default function Dashboard() {
                         }`}
                         title={!upgradeSortingDisabled && orderedGroupsForModal.length > 1 ? "Drag to reorder group" : undefined}
                         aria-label={!upgradeSortingDisabled && orderedGroupsForModal.length > 1 ? `Drag to reorder ${group.name}` : undefined}
+                        onPointerDown={(event) => handleGroupPointerDown(event, group.key)}
+                        style={{ touchAction: "none" }}
                       >
                         <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 6h.01M8 12h.01M8 18h.01M16 6h.01M16 12h.01M16 18h.01" />
@@ -891,13 +1240,6 @@ export default function Dashboard() {
                     )}
                   </div>
                   <ul
-                    ref={(node) => {
-                      if (node) {
-                        systemListRefs.current.set(group.key, node);
-                      } else {
-                        systemListRefs.current.delete(group.key);
-                      }
-                    }}
                     data-system-list-group={group.id ?? UNGROUPED_KEY}
                     className="min-h-6 space-y-2"
                   >
@@ -925,6 +1267,8 @@ export default function Dashboard() {
                             }`}
                             title={!upgradeSortingDisabled ? "Drag to set upgrade group and order" : undefined}
                             aria-label={!upgradeSortingDisabled ? `Drag to set upgrade group and order for ${s.name}` : undefined}
+                            onPointerDown={(event) => handleSystemPointerDown(event, s.id)}
+                            style={{ touchAction: "none" }}
                           >
                             <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 6h.01M8 12h.01M8 18h.01M16 6h.01M16 12h.01M16 18h.01" />

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -117,6 +117,55 @@ function supportsDefaultUpgradeModeOverride(system: System): boolean {
   return managers.includes("apt") || managers.includes("dnf");
 }
 
+function getUpgradeSystemRowClass({
+  hasUpdates,
+  isSelected,
+}: {
+  hasUpdates: boolean;
+  isSelected: boolean;
+}): string {
+  const baseClass =
+    "grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-lg border p-3 transition-colors sm:grid-cols-[auto_minmax(0,1fr)_auto]";
+
+  if (!hasUpdates) {
+    return [
+      baseClass,
+      "border-dashed border-slate-300 bg-slate-50/60",
+      "dark:border-slate-600 dark:bg-slate-900/20",
+    ].join(" ");
+  }
+
+  if (isSelected) {
+    return [
+      baseClass,
+      "border-slate-300 bg-white ring-1 ring-inset ring-slate-100",
+      "dark:border-slate-500 dark:bg-slate-700/55 dark:ring-slate-500/20",
+    ].join(" ");
+  }
+
+  return [
+    baseClass,
+    "border-slate-200 bg-slate-50/70",
+    "dark:border-slate-700 dark:bg-slate-800/45",
+  ].join(" ");
+}
+
+function getUpgradeSystemNameClass({
+  hasUpdates,
+  isSelected,
+}: {
+  hasUpdates: boolean;
+  isSelected: boolean;
+}): string {
+  if (!hasUpdates) {
+    return "block min-w-0 flex-1 truncate text-sm text-slate-500 dark:text-slate-400";
+  }
+
+  return isSelected
+    ? "block min-w-0 flex-1 truncate text-sm font-medium text-slate-900 dark:text-slate-50"
+    : "block min-w-0 flex-1 truncate text-sm text-slate-500 dark:text-slate-400";
+}
+
 function isDefaultFullUpgradeEnabled(system: System): boolean {
   const managers = getActiveManagers(system);
   const configs = parseConfigObject(system.pkgManagerConfigs);
@@ -745,7 +794,7 @@ export default function Dashboard() {
         </p>
         {modalSystems.length > 0 ? (
           <div className="mb-4">
-            <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="mb-3 flex items-center justify-between gap-2">
               <button
                 type="button"
                 role="switch"
@@ -772,7 +821,7 @@ export default function Dashboard() {
                   type="button"
                   onClick={handleCreateGroup}
                   disabled={createUpgradeGroup.isPending}
-                  className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-50 dark:text-slate-200 dark:hover:bg-slate-700 sm:w-auto"
+                  className="shrink-0 rounded-md border border-border px-3 py-1.5 text-xs text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-50 dark:text-slate-200 dark:hover:bg-slate-700"
                 >
                   Add group
                 </button>
@@ -792,7 +841,7 @@ export default function Dashboard() {
                   data-real-group={group.id ? "true" : "false"}
                   className="rounded-lg border border-border bg-slate-50/60 p-2 dark:bg-slate-800/40"
                 >
-                  <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="mb-2 flex items-center justify-between gap-2">
                     <div className="flex min-w-0 items-center gap-2">
                       <span
                         className={`upgrade-group-drag-handle shrink-0 rounded-md p-1 text-slate-400 transition-colors ${
@@ -813,7 +862,7 @@ export default function Dashboard() {
                       <Badge variant="muted" small>{group.systems.length}</Badge>
                     </div>
                     {upgradeEditMode && group.realGroup && (
-                      <div className="flex gap-2">
+                      <div className="flex shrink-0 gap-2">
                         <button
                           type="button"
                           onClick={() => openRenameGroup(group.realGroup!)}
@@ -864,11 +913,7 @@ export default function Dashboard() {
                         <li
                           key={s.id}
                           data-system-id={s.id}
-                          className={`grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-lg border p-3 sm:grid-cols-[auto_minmax(0,1fr)_auto] ${
-                            isSelected
-                              ? "bg-white dark:bg-slate-800/80"
-                              : "bg-slate-50 dark:bg-slate-700/50"
-                          } ${hasUpdates ? "border-border" : "border-dashed border-slate-300 opacity-70 dark:border-slate-600"}`}
+                          className={getUpgradeSystemRowClass({ hasUpdates, isSelected })}
                         >
                           <span
                             className={`upgrade-drag-handle shrink-0 rounded-md p-1 text-slate-400 transition-colors ${
@@ -892,7 +937,7 @@ export default function Dashboard() {
                               className="shrink-0 rounded"
                               aria-label={`${isSelected ? "Exclude" : "Include"} ${s.name} in Upgrade All`}
                             />
-                            <span className="block min-w-0 flex-1 truncate text-sm text-slate-700 dark:text-slate-200">
+                            <span className={getUpgradeSystemNameClass({ hasUpdates, isSelected })}>
                               {s.name}
                             </span>
                             {canOverrideMode && (

--- a/client/pages/Scripts.tsx
+++ b/client/pages/Scripts.tsx
@@ -20,6 +20,7 @@ import {
   type PlaceholderHelpEntry,
   type ScriptDefinition,
   type ScriptOperation,
+  type ScriptOperationProfile,
   type ScriptStep,
   type ScriptType,
   type CustomParserConfig,
@@ -41,6 +42,104 @@ const OPERATION_LABELS: Record<ScriptOperation, string> = {
   system_info: "System info",
   reboot: "Reboot",
 };
+const FALLBACK_OPERATION_PROFILES: ScriptOperationProfile[] = [
+  {
+    operation: "detect",
+    label: OPERATION_LABELS.detect,
+    allowedTypes: ["package_manager"],
+    purpose: "Determines whether a package manager is available on a remote system.",
+    stepBehavior: "Detection uses exactly one command so the result is unambiguous.",
+    outputConsumer: "The command must exit with 0 and print found on stdout to enable the manager.",
+    parserBehavior: "No update parser is used for detection output.",
+    exitCodeBehavior: "Exit code 0 with found means detected; any other result is treated as not detected.",
+    relevantPlaceholders: ["{{manager}}", "{{config.someKey}}"],
+    defaultStepBadge: "detection output",
+  },
+  {
+    operation: "check_updates",
+    label: OPERATION_LABELS.check_updates,
+    allowedTypes: ["package_manager"],
+    purpose: "Refreshes package metadata and turns command output into cached update rows.",
+    stepBehavior: "Steps run in order and stop at the first failed step.",
+    outputConsumer: "Built-in parsers inspect the command results they need; custom parsers read one selected step, defaulting to the last step.",
+    parserBehavior: "Custom package managers need an update regex with packageName and newVersion groups.",
+    exitCodeBehavior: "Built-in parsers and custom success/update exit-code lists decide whether a non-zero exit code is acceptable.",
+    relevantPlaceholders: ["{{manager}}", "{{config.someKey}}", "{{sudo:COMMAND}}"],
+    defaultStepBadge: "parser input",
+  },
+  {
+    operation: "repair_issue",
+    label: OPERATION_LABELS.repair_issue,
+    allowedTypes: ["package_manager"],
+    purpose: "Runs the repair action offered for package-manager issue banners.",
+    stepBehavior: "The configured repair steps run in order and stop at the first failed step.",
+    outputConsumer: "Output is streamed live and stored in activity history; it is not parsed into update rows.",
+    parserBehavior: "No parser configuration is used.",
+    exitCodeBehavior: "A non-zero exit code marks the repair operation as failed.",
+    relevantPlaceholders: ["{{manager}}", "{{config.someKey}}", "{{sudo:COMMAND}}"],
+    defaultStepBadge: "streamed only",
+  },
+  {
+    operation: "upgrade_all",
+    label: OPERATION_LABELS.upgrade_all,
+    allowedTypes: ["package_manager"],
+    purpose: "Installs all available updates for one package manager.",
+    stepBehavior: "Upgrade commands run as the operation body for the selected manager.",
+    outputConsumer: "Output is streamed live, stored in history, and followed by a recheck.",
+    parserBehavior: "No parser configuration is used while upgrading.",
+    exitCodeBehavior: "A non-zero exit code marks the upgrade as failed.",
+    relevantPlaceholders: ["{{manager}}", "{{config.someKey}}", "{{sudo:COMMAND}}"],
+    defaultStepBadge: "streamed only",
+  },
+  {
+    operation: "full_upgrade_all",
+    label: OPERATION_LABELS.full_upgrade_all,
+    allowedTypes: ["package_manager"],
+    purpose: "Runs the fuller upgrade mode for package managers that support it.",
+    stepBehavior: "Full-upgrade commands run as the operation body for the selected manager.",
+    outputConsumer: "Output is streamed live, stored in history, and followed by a recheck.",
+    parserBehavior: "No parser configuration is used while upgrading.",
+    exitCodeBehavior: "A non-zero exit code marks the full upgrade as failed.",
+    relevantPlaceholders: ["{{manager}}", "{{config.someKey}}", "{{sudo:COMMAND}}"],
+    defaultStepBadge: "streamed only",
+  },
+  {
+    operation: "upgrade_selected",
+    label: OPERATION_LABELS.upgrade_selected,
+    allowedTypes: ["package_manager"],
+    purpose: "Upgrades the packages selected by the user.",
+    stepBehavior: "Selected package placeholders are resolved immediately before SSH execution.",
+    outputConsumer: "Output is streamed live, stored in history, and followed by a recheck.",
+    parserBehavior: "No parser configuration is used while upgrading selected packages.",
+    exitCodeBehavior: "A non-zero exit code marks the selected-package upgrade as failed.",
+    relevantPlaceholders: ["{{package}}", "{{packages}}", "{{quotedPackage}}", "{{quotedPackages}}", "{{manager}}", "{{config.someKey}}", "{{sudo:COMMAND}}"],
+    defaultStepBadge: "streamed only",
+  },
+  {
+    operation: "system_info",
+    label: OPERATION_LABELS.system_info,
+    allowedTypes: ["system"],
+    purpose: "Collects OS, kernel, uptime, resource, boot, and reboot-required details.",
+    stepBehavior: "System-info steps run in order and their output is consumed by the configured mapping mode.",
+    outputConsumer: "The built-in parser reads dashboard sections; custom section mapping reads named output sections into system fields.",
+    parserBehavior: "Use built-in mode for copied standard scripts, or sectioned mode for custom output.",
+    exitCodeBehavior: "A non-zero exit code marks system-info collection as failed.",
+    relevantPlaceholders: ["{{sudo:COMMAND}}"],
+    defaultStepBadge: "system fields",
+  },
+  {
+    operation: "reboot",
+    label: OPERATION_LABELS.reboot,
+    allowedTypes: ["system"],
+    purpose: "Reboots the remote system after any configured safety checks pass.",
+    stepBehavior: "Reboot steps run in order and stop before later steps when an earlier step fails.",
+    outputConsumer: "Output is streamed live and stored in activity history; it is not parsed into system fields or update rows.",
+    parserBehavior: "No parser configuration is used.",
+    exitCodeBehavior: "A non-zero exit code before the reboot command prevents later steps from running.",
+    relevantPlaceholders: ["{{sudo:COMMAND}}"],
+    defaultStepBadge: "streamed only",
+  },
+];
 const PACKAGE_MANAGER_OPERATIONS: ScriptOperation[] = [
   "detect",
   "check_updates",
@@ -529,6 +628,102 @@ function ScriptReferenceSection({
   );
 }
 
+function operationProfileMap(profiles: ScriptOperationProfile[] | undefined): Map<ScriptOperation, ScriptOperationProfile> {
+  return new Map((profiles?.length ? profiles : FALLBACK_OPERATION_PROFILES).map((profile) => [
+    profile.operation,
+    profile,
+  ]));
+}
+
+function RuntimeBehaviorPanel({
+  profile,
+  parseStepLabel,
+  parseStepOutOfRange,
+  usesBuiltinParser,
+  showParserConfig,
+}: {
+  profile: ScriptOperationProfile;
+  parseStepLabel: string;
+  parseStepOutOfRange: boolean;
+  usesBuiltinParser: boolean;
+  showParserConfig: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const outputDetail = showParserConfig
+    ? `Custom parser output: ${parseStepLabel}.`
+    : usesBuiltinParser && profile.operation === "check_updates"
+      ? "Built-in parser chooses the required command output from the completed steps."
+      : profile.outputConsumer;
+
+  return (
+    <section className="rounded-lg border border-blue-200 bg-blue-50/70 text-sm text-blue-950 dark:border-blue-900/50 dark:bg-blue-950/20 dark:text-blue-100">
+      <button
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        className="flex w-full items-center justify-between gap-3 p-3 text-left"
+        aria-expanded={open}
+      >
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs font-medium uppercase tracking-wide text-blue-700 dark:text-blue-300">
+              Runtime behavior
+            </span>
+            <Badge variant="info" small>{profile.label}</Badge>
+          </div>
+          <div className="mt-1 text-xs text-blue-700/80 dark:text-blue-200/80">
+            Steps, output, parser, and exit codes
+          </div>
+        </div>
+        <svg
+          className={`h-5 w-5 shrink-0 text-blue-600 transition-transform dark:text-blue-300 ${open ? "rotate-180" : ""}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {open && (
+        <div className="border-t border-blue-200 p-3 dark:border-blue-900/50">
+          <p>{profile.purpose}</p>
+          <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-2">
+            <div>
+              <div className="text-xs font-medium uppercase tracking-wide text-blue-700 dark:text-blue-300">
+                Steps
+              </div>
+              <p className="mt-1 text-blue-900/80 dark:text-blue-100/80">{profile.stepBehavior}</p>
+            </div>
+            <div>
+              <div className="text-xs font-medium uppercase tracking-wide text-blue-700 dark:text-blue-300">
+                Output
+              </div>
+              <p className="mt-1 text-blue-900/80 dark:text-blue-100/80">{outputDetail}</p>
+            </div>
+            <div>
+              <div className="text-xs font-medium uppercase tracking-wide text-blue-700 dark:text-blue-300">
+                Parser
+              </div>
+              <p className="mt-1 text-blue-900/80 dark:text-blue-100/80">{profile.parserBehavior}</p>
+            </div>
+            <div>
+              <div className="text-xs font-medium uppercase tracking-wide text-blue-700 dark:text-blue-300">
+                Exit codes
+              </div>
+              <p className="mt-1 text-blue-900/80 dark:text-blue-100/80">{profile.exitCodeBehavior}</p>
+            </div>
+          </div>
+          {parseStepOutOfRange && (
+            <div className="mt-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100">
+              The saved parser step no longer exists. Choose an existing step before saving this script.
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
 function readPackageManagersPanelOpen(): boolean {
   if (typeof window === "undefined") return false;
   return window.localStorage.getItem(PACKAGE_MANAGERS_PANEL_STORAGE_KEY) === "1";
@@ -577,10 +772,11 @@ function buildSystemInfoConfig(
   return Object.keys(config).length ? config : null;
 }
 
-function ScriptEditor({
+export function ScriptEditor({
   script,
   packageManagers,
   placeholders,
+  operationProfiles,
   onSave,
   onCancel,
   busy,
@@ -588,6 +784,7 @@ function ScriptEditor({
   script: ScriptDefinition;
   packageManagers: Array<{ name: string; label: string; configEntries?: CustomPackageManagerConfigEntry[] }>;
   placeholders: PlaceholderHelpEntry[];
+  operationProfiles?: ScriptOperationProfile[];
   onSave: (script: ScriptDefinition) => void;
   onCancel: () => void;
   busy?: boolean;
@@ -620,6 +817,8 @@ function ScriptEditor({
   const stepsListRef = useRef<HTMLDivElement | null>(null);
   const sortableRef = useRef<Sortable | null>(null);
   const operationOptions = draft.type === "system" ? SYSTEM_OPERATIONS : PACKAGE_MANAGER_OPERATIONS;
+  const profiles = useMemo(() => operationProfileMap(operationProfiles), [operationProfiles]);
+  const operationProfile = profiles.get(draft.operation) ?? FALLBACK_OPERATION_PROFILES[0];
   const selectedPackageManager = draft.pkgManager ?? "";
   const usesBuiltinParser = selectedPackageManager ? BUILTIN_PACKAGE_MANAGERS.includes(selectedPackageManager) : false;
   const customConfigKeys = packageManagers
@@ -653,6 +852,39 @@ function ScriptEditor({
     draft.operation === "check_updates" &&
     !usesBuiltinParser;
   const showSystemInfoConfig = draft.type === "system" && draft.operation === "system_info";
+  const singleStepOperation = draft.operation === "detect";
+  const explicitParseStep = parserConfig.parseStep.trim();
+  const parsedStepNumber = explicitParseStep
+    ? Number.parseInt(explicitParseStep, 10)
+    : steps.length - 1;
+  const parsedStepIndex = Number.isInteger(parsedStepNumber) ? parsedStepNumber : steps.length - 1;
+  const parseStepOutOfRange =
+    showParserConfig &&
+    (!Number.isInteger(parsedStepNumber) || parsedStepNumber < 0 || parsedStepNumber >= steps.length);
+  const parsedStepLabel = parseStepOutOfRange
+    ? Number.isInteger(parsedStepNumber)
+      ? `missing step ${parsedStepNumber + 1}`
+      : "invalid parser step"
+    : steps[parsedStepIndex]?.label || `step ${parsedStepIndex + 1}`;
+  const parseStepSummary = showParserConfig
+    ? parseStepOutOfRange
+      ? parsedStepLabel
+      : `Step ${parsedStepIndex + 1}: ${parsedStepLabel}`
+    : "";
+
+  const stepBadge = (index: number): string => {
+    if (draft.operation === "detect") return index === 0 ? "detection output" : "not used";
+    if (draft.operation === "check_updates") {
+      if (showParserConfig) {
+        if (parseStepOutOfRange) return "streamed only";
+        return index === parsedStepIndex ? "parsed output" : "streamed only";
+      }
+      return usesBuiltinParser ? "parser input" : operationProfile.defaultStepBadge;
+    }
+    if (draft.operation === "system_info") return "system fields";
+    if (draft.operation === "reboot") return index < steps.length - 1 ? "reboot guard" : "reboot command";
+    return operationProfile.defaultStepBadge;
+  };
 
   useEffect(() => {
     stepsRef.current = steps;
@@ -703,6 +935,7 @@ function ScriptEditor({
   };
 
   const addStep = () => {
+    if (singleStepOperation) return;
     setSteps((current) => [
       ...current,
       { label: `Step ${current.length + 1}`, command: "" },
@@ -745,6 +978,9 @@ function ScriptEditor({
       }));
       if (normalizedSteps.some((step) => !step.label || !step.command)) {
         throw new Error("Each step needs a label and command");
+      }
+      if (draft.operation === "detect" && normalizedSteps.length !== 1) {
+        throw new Error("Detection scripts use exactly one step");
       }
       const pkgManager = draft.type === "package_manager"
         ? draft.pkgManager?.trim() || null
@@ -839,6 +1075,14 @@ function ScriptEditor({
         />
       </div>
 
+      <RuntimeBehaviorPanel
+        profile={operationProfile}
+        parseStepLabel={parseStepSummary}
+        parseStepOutOfRange={parseStepOutOfRange}
+        usesBuiltinParser={usesBuiltinParser}
+        showParserConfig={showParserConfig}
+      />
+
       {showPackageManagerControls && (
         <ScriptReferenceSection
           title="Config Keys"
@@ -861,13 +1105,19 @@ function ScriptEditor({
           <button
             type="button"
             onClick={addStep}
-            className="inline-flex items-center justify-center w-8 h-8 rounded-lg border border-border hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors text-lg leading-none"
-            title="Add step"
+            disabled={singleStepOperation}
+            className="inline-flex items-center justify-center w-8 h-8 rounded-lg border border-border hover:bg-slate-50 dark:hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-40 transition-colors text-lg leading-none"
+            title={singleStepOperation ? "Detection scripts use one step" : "Add step"}
             aria-label="Add step"
           >
             +
           </button>
         </div>
+        {singleStepOperation && (
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Detection scripts use one command. It must exit with 0 and print found when the package manager is available.
+          </p>
+        )}
         <div ref={stepsListRef} className="space-y-3">
           {steps.map((step, index) => (
             <div key={`${index}-${step.label}`} className="rounded-lg border border-border bg-slate-50/60 dark:bg-slate-900/30 p-3">
@@ -887,7 +1137,12 @@ function ScriptEditor({
                 </button>
                 <div className="min-w-0 flex-1 space-y-3">
                   <div>
-                    <label className={labelClass}>Step {index + 1} Label</label>
+                    <div className="mb-1 flex flex-wrap items-center gap-2">
+                      <label className={`${labelClass} mb-0`}>Step {index + 1} Label</label>
+                      <span className="rounded-full bg-slate-200/70 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                        {stepBadge(index)}
+                      </span>
+                    </div>
                     <input
                       value={step.label}
                       onChange={(e) => updateStep(index, { label: e.target.value })}
@@ -931,19 +1186,37 @@ function ScriptEditor({
           </summary>
           <div className="mt-4 space-y-4">
             <p className="text-sm text-slate-500 dark:text-slate-400">
-              Use named regex groups to turn check output into update rows. Required groups are packageName and newVersion.
+              Use named regex groups to turn the selected step output into update rows. Required groups are packageName and newVersion; other step output stays in activity history.
             </p>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               <div>
-                <label className={labelClass}>Parse Step</label>
-                <input
-                  type="number"
-                  min={0}
+                <label className={labelClass}>Output to Parse</label>
+                <select
                   value={parserConfig.parseStep}
                   onChange={(e) => setParserConfig({ ...parserConfig, parseStep: e.target.value })}
                   className={inputClass}
-                  placeholder="last step"
-                />
+                >
+                  <option value="">
+                    Last step ({steps.at(-1)?.label || `Step ${steps.length}`})
+                  </option>
+                  {steps.map((step, index) => (
+                    <option key={`${index}-${step.label}`} value={index.toString()}>
+                      Step {index + 1}: {step.label || `Step ${index + 1}`}
+                    </option>
+                  ))}
+                  {parseStepOutOfRange && (
+                    <option value={parserConfig.parseStep}>
+                      {Number.isInteger(parsedStepNumber)
+                        ? `Missing step ${parsedStepNumber + 1}`
+                        : "Invalid parser step"}
+                    </option>
+                  )}
+                </select>
+                {parseStepOutOfRange && (
+                  <p className="mt-1 text-xs text-amber-700 dark:text-amber-300">
+                    The saved parser step is outside the current step list.
+                  </p>
+                )}
               </div>
               <div>
                 <label className={labelClass}>Successful Exit Codes</label>
@@ -1753,6 +2026,7 @@ export default function Scripts() {
             script={editing}
             packageManagers={packageManagerOptions}
             placeholders={data?.placeholders ?? []}
+            operationProfiles={data?.operationProfiles}
             onSave={saveScript}
             onCancel={() => setEditing(null)}
             busy={createScript.isPending || updateScript.isPending}

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -114,6 +114,14 @@ export function initDatabase(dbPath: string): BetterSQLite3Database<typeof schem
   )`);
   migrateCredentialsTable();
 
+  _db.run(sql`CREATE TABLE IF NOT EXISTS upgrade_groups (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`);
+
   _db.run(sql`CREATE TABLE IF NOT EXISTS systems (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     sort_order INTEGER NOT NULL DEFAULT 0,
@@ -149,6 +157,7 @@ export function initDatabase(dbPath: string): BetterSQLite3Database<typeof schem
     memory TEXT,
     disk TEXT,
     exclude_from_upgrade_all INTEGER NOT NULL DEFAULT 0,
+    upgrade_group_id INTEGER REFERENCES upgrade_groups(id) ON DELETE SET NULL,
     upgrade_order INTEGER NOT NULL DEFAULT 1,
     hidden INTEGER NOT NULL DEFAULT 0,
     needs_reboot INTEGER NOT NULL DEFAULT 0,
@@ -231,6 +240,39 @@ export function initDatabase(dbPath: string): BetterSQLite3Database<typeof schem
     output TEXT,
     error TEXT,
     started_at TEXT NOT NULL DEFAULT (datetime('now')),
+    completed_at TEXT
+  )`);
+
+  _db.run(sql`CREATE TABLE IF NOT EXISTS upgrade_batches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    status TEXT NOT NULL DEFAULT 'queued',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    started_at TEXT,
+    completed_at TEXT
+  )`);
+
+  _db.run(sql`CREATE TABLE IF NOT EXISTS upgrade_batch_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    batch_id INTEGER NOT NULL REFERENCES upgrade_batches(id) ON DELETE CASCADE,
+    system_id INTEGER NOT NULL REFERENCES systems(id) ON DELETE CASCADE,
+    group_id INTEGER REFERENCES upgrade_groups(id) ON DELETE SET NULL,
+    group_sort_order INTEGER NOT NULL DEFAULT 0,
+    system_sort_order INTEGER NOT NULL DEFAULT 0,
+    default_upgrade_mode_override TEXT,
+    status TEXT NOT NULL DEFAULT 'queued',
+    command TEXT,
+    pkg_manager TEXT NOT NULL DEFAULT 'system',
+    history_id INTEGER REFERENCES update_history(id) ON DELETE SET NULL,
+    current_pkg_manager TEXT,
+    current_command TEXT,
+    remote_pid INTEGER,
+    remote_log_file TEXT,
+    remote_exit_file TEXT,
+    remote_script_file TEXT,
+    pre_upgrade_update_count INTEGER,
+    error TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    started_at TEXT,
     completed_at TEXT
   )`);
 
@@ -630,6 +672,11 @@ export function initDatabase(dbPath: string): BetterSQLite3Database<typeof schem
     // Column already exists
   }
   try {
+    _db.run(sql`ALTER TABLE systems ADD COLUMN upgrade_group_id INTEGER`);
+  } catch {
+    // Column already exists
+  }
+  try {
     _db.run(sql`ALTER TABLE systems ADD COLUMN upgrade_order INTEGER NOT NULL DEFAULT 1`);
   } catch {
     // Column already exists
@@ -751,7 +798,13 @@ export function initDatabase(dbPath: string): BetterSQLite3Database<typeof schem
         THEN NULL
       ELSE 'Server restarted while operation was in progress'
     END
-    WHERE status = 'started'`);
+    WHERE status = 'started'
+      AND id NOT IN (
+        SELECT history_id
+        FROM upgrade_batch_items
+        WHERE history_id IS NOT NULL
+          AND status IN ('queued', 'running')
+      )`);
 
   // Cleanup: remove obsolete settings
   _db.run(sql`DELETE FROM settings WHERE key IN ('check_flatpak', 'check_snap', 'auto_hide_kept_back_updates')`);
@@ -1085,6 +1138,7 @@ function rebuildSystemsTable(
       memory TEXT,
       disk TEXT,
       exclude_from_upgrade_all INTEGER NOT NULL DEFAULT 0,
+      upgrade_group_id INTEGER,
       upgrade_order INTEGER NOT NULL DEFAULT 1,
       hidden INTEGER NOT NULL DEFAULT 0,
       needs_reboot INTEGER NOT NULL DEFAULT 0,
@@ -1135,6 +1189,7 @@ function rebuildSystemsTable(
     "memory",
     "disk",
     "exclude_from_upgrade_all",
+    "upgrade_group_id",
     "upgrade_order",
     "hidden",
     "needs_reboot",
@@ -1188,6 +1243,7 @@ function rebuildSystemsTable(
     "memory",
     "disk",
     "exclude_from_upgrade_all",
+    "upgrade_group_id",
     "upgrade_order",
     "hidden",
     "needs_reboot",

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -101,6 +101,10 @@ export const systems = sqliteTable(
     excludeFromUpgradeAll: integer("exclude_from_upgrade_all")
       .notNull()
       .default(0),
+    upgradeGroupId: integer("upgrade_group_id").references(
+      (): AnySQLiteColumn => upgradeGroups.id,
+      { onDelete: "set null" }
+    ),
     upgradeOrder: integer("upgrade_order").notNull().default(1),
     hidden: integer("hidden").notNull().default(0),
     needsReboot: integer("needs_reboot").notNull().default(0),
@@ -116,6 +120,18 @@ export const systems = sqliteTable(
       .default(sql`(datetime('now'))`),
   }
 );
+
+export const upgradeGroups = sqliteTable("upgrade_groups", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  sortOrder: integer("sort_order").notNull().default(0),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+});
 
 export const updateCache = sqliteTable(
   "update_cache",
@@ -230,6 +246,47 @@ export const updateHistory = sqliteTable("update_history", {
   startedAt: text("started_at")
     .notNull()
     .default(sql`(datetime('now'))`),
+  completedAt: text("completed_at"),
+});
+
+export const upgradeBatches = sqliteTable("upgrade_batches", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  status: text("status").notNull().default("queued"),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+  startedAt: text("started_at"),
+  completedAt: text("completed_at"),
+});
+
+export const upgradeBatchItems = sqliteTable("upgrade_batch_items", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  batchId: integer("batch_id")
+    .notNull()
+    .references(() => upgradeBatches.id, { onDelete: "cascade" }),
+  systemId: integer("system_id")
+    .notNull()
+    .references(() => systems.id, { onDelete: "cascade" }),
+  groupId: integer("group_id").references(() => upgradeGroups.id, { onDelete: "set null" }),
+  groupSortOrder: integer("group_sort_order").notNull().default(0),
+  systemSortOrder: integer("system_sort_order").notNull().default(0),
+  defaultUpgradeModeOverride: text("default_upgrade_mode_override"),
+  status: text("status").notNull().default("queued"),
+  command: text("command"),
+  pkgManager: text("pkg_manager").notNull().default("system"),
+  historyId: integer("history_id").references(() => updateHistory.id, { onDelete: "set null" }),
+  currentPkgManager: text("current_pkg_manager"),
+  currentCommand: text("current_command"),
+  remotePid: integer("remote_pid"),
+  remoteLogFile: text("remote_log_file"),
+  remoteExitFile: text("remote_exit_file"),
+  remoteScriptFile: text("remote_script_file"),
+  preUpgradeUpdateCount: integer("pre_upgrade_update_count"),
+  error: text("error"),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+  startedAt: text("started_at"),
   completedAt: text("completed_at"),
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -13,6 +13,7 @@ import * as scheduler from "./services/scheduler";
 import { createApp } from "./app";
 import { logger } from "./logger";
 import * as notificationRuntime from "./services/notification-runtime";
+import * as upgradeBatchService from "./services/upgrade-batch-service";
 import { migrateEncryptionSalt, migrateLegacyAuthTags } from "./encryption-migration";
 import { syncSSHManagerWithSettings } from "./services/settings-service";
 
@@ -68,6 +69,7 @@ syncSSHManagerWithSettings();
 // Start background scheduler
 logger.info("Starting update scheduler");
 scheduler.start();
+upgradeBatchService.resumeUpgradeBatches();
 
 // Create and start Hono app
 const app = createApp();

--- a/server/routes/dashboard.ts
+++ b/server/routes/dashboard.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import * as systemService from "../services/system-service";
 import * as cacheService from "../services/cache-service";
 import * as updateService from "../services/update-service";
+import * as upgradeBatchService from "../services/upgrade-batch-service";
 
 const dashboard = new Hono();
 
@@ -21,7 +22,7 @@ dashboard.get("/stats", (c) => {
     cacheAge: cacheService.getCacheAge(s.id),
     cacheTimestamp: cacheService.getCacheTimestamp(s.id),
     isStale: cacheService.isCacheStale(s.id),
-    activeOperation: updateService.getActiveOperation(s.id),
+    activeOperation: updateService.getActiveOperation(s.id) ?? upgradeBatchService.getQueuedOrRunningOperation(s.id),
   }));
 
   const total = systemsWithMeta.length;
@@ -60,7 +61,7 @@ dashboard.get("/systems", (c) => {
     cacheAge: cacheService.getCacheAge(s.id),
     cacheTimestamp: cacheService.getCacheTimestamp(s.id),
     isStale: cacheService.isCacheStale(s.id),
-    activeOperation: updateService.getActiveOperation(s.id),
+    activeOperation: updateService.getActiveOperation(s.id) ?? upgradeBatchService.getQueuedOrRunningOperation(s.id),
   }));
 
   return c.json({ systems: systemsWithMeta });

--- a/server/routes/systems.ts
+++ b/server/routes/systems.ts
@@ -5,6 +5,7 @@ import { buildCommandReference } from "../services/command-reference";
 import * as hiddenUpdateService from "../services/hidden-update-service";
 import * as packageIssueService from "../services/package-manager-issue-service";
 import * as updateService from "../services/update-service";
+import * as upgradeBatchService from "../services/upgrade-batch-service";
 import * as notificationRuntime from "../services/notification-runtime";
 import * as scriptService from "../services/script-service";
 import { getSSHManager } from "../ssh/connection";
@@ -163,6 +164,41 @@ function parseSystemIdList(value: unknown): number[] | null {
   if (ids.some((id) => id === null)) return null;
 
   return ids as number[];
+}
+
+function parseUpgradeGroupOrder(value: unknown): Array<number | "ungrouped"> | null {
+  if (!Array.isArray(value)) return null;
+
+  const keys: Array<number | "ungrouped"> = [];
+  for (const entry of value) {
+    if (entry === "ungrouped") {
+      keys.push("ungrouped");
+      continue;
+    }
+    const id = parseId(String(entry));
+    if (!id) return null;
+    keys.push(id);
+  }
+  return keys;
+}
+
+function parseSystemUpgradeGroupItems(value: unknown): Array<{ systemId: number; groupId: number | null; upgradeOrder: number }> | null {
+  if (!Array.isArray(value)) return null;
+  const items: Array<{ systemId: number; groupId: number | null; upgradeOrder: number }> = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+    const raw = entry as Record<string, unknown>;
+    const systemId = parseId(String(raw.systemId));
+    const groupId =
+      raw.groupId === null || raw.groupId === undefined
+        ? null
+        : parseId(String(raw.groupId));
+    const upgradeOrder = Number(raw.upgradeOrder);
+    if (!systemId || (raw.groupId !== null && raw.groupId !== undefined && !groupId)) return null;
+    if (!Number.isInteger(upgradeOrder) || upgradeOrder <= 0) return null;
+    items.push({ systemId, groupId, upgradeOrder });
+  }
+  return items;
 }
 
 function getSystemWriteErrorResponse(error: unknown): Response | null {
@@ -395,6 +431,87 @@ function getLastCheckMap(systemIds: number[]): Map<number, updateService.LastChe
   return updateService.getLatestCompletedChecks(systemIds);
 }
 
+systems.get("/upgrade-groups", (c) => {
+  return c.json({
+    groups: systemService.listUpgradeGroups(),
+    ungroupedSortOrder: systemService.getUngroupedUpgradeGroupSortOrder(),
+  });
+});
+
+systems.post("/upgrade-groups", async (c) => {
+  const body = asObject(await c.req.json().catch(() => null));
+  if (!body || typeof body.name !== "string") {
+    return c.json({ error: "name is required" }, 400);
+  }
+  try {
+    const id = systemService.createUpgradeGroup(body.name);
+    return c.json({ id }, 201);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to create upgrade group";
+    return c.json({ error: message }, 400);
+  }
+});
+
+systems.put("/upgrade-groups/reorder", async (c) => {
+  const body = asObject(await c.req.json().catch(() => null));
+  if (!body) return c.json({ error: "Invalid request body" }, 400);
+  const groupKeys = parseUpgradeGroupOrder(body.groupKeys ?? body.groupIds);
+  if (!groupKeys) {
+    return c.json({ error: "groupKeys must include group IDs and Ungrouped" }, 400);
+  }
+  try {
+    systemService.reorderUpgradeGroups(groupKeys);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to reorder upgrade groups";
+    return c.json({ error: message }, 400);
+  }
+  return c.json({ status: "ok" });
+});
+
+systems.put("/upgrade-groups/systems", async (c) => {
+  const body = asObject(await c.req.json().catch(() => null));
+  if (!body) return c.json({ error: "Invalid request body" }, 400);
+  const items = parseSystemUpgradeGroupItems(body.items);
+  if (!items) {
+    return c.json({ error: "items must include systemId, groupId, and upgradeOrder" }, 400);
+  }
+  try {
+    systemService.moveSystemsForUpgradeGroups(items);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to update upgrade group systems";
+    return c.json({ error: message }, 400);
+  }
+  return c.json({ status: "ok" });
+});
+
+systems.put("/upgrade-groups/:id", async (c) => {
+  const id = parseId(c.req.param("id"));
+  if (!id) return c.json({ error: "Invalid group ID" }, 400);
+  const body = asObject(await c.req.json().catch(() => null));
+  if (!body || typeof body.name !== "string") {
+    return c.json({ error: "name is required" }, 400);
+  }
+  try {
+    systemService.updateUpgradeGroup(id, body.name);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to update upgrade group";
+    return c.json({ error: message }, error instanceof Error && error.message.includes("not found") ? 404 : 400);
+  }
+  return c.json({ status: "ok" });
+});
+
+systems.delete("/upgrade-groups/:id", async (c) => {
+  const id = parseId(c.req.param("id"));
+  if (!id) return c.json({ error: "Invalid group ID" }, 400);
+  try {
+    systemService.deleteUpgradeGroup(id);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to delete upgrade group";
+    return c.json({ error: message }, error instanceof Error && error.message.includes("not found") ? 404 : 400);
+  }
+  return c.json({ status: "ok" });
+});
+
 function isHostKeyFailure(summary: updateService.LastCheckSummary | null | undefined): boolean {
   const error = summary?.error ?? "";
   return /HostKeyVerificationError|SSH host key approval required|SSH host key verification failed/i.test(
@@ -448,7 +565,7 @@ systems.get("/", (c) => {
     lastCheck: lastChecks.get(s.id) ?? null,
     cacheAge: cacheService.getCacheAge(s.id),
     cacheTimestamp: cacheService.getCacheTimestamp(s.id),
-    activeOperation: updateService.getActiveOperation(s.id),
+    activeOperation: updateService.getActiveOperation(s.id) ?? upgradeBatchService.getQueuedOrRunningOperation(s.id),
     supportsFullUpgrade: updateService.supportsFullUpgrade(s.id),
     packageIssueCount: issueCounts.get(s.id) ?? 0,
   }));
@@ -482,7 +599,7 @@ systems.get("/:id", (c) => {
       cacheAge: cacheService.getCacheAge(id),
       cacheTimestamp: cacheService.getCacheTimestamp(id),
       isStale: cacheService.isCacheStale(id),
-      activeOperation: updateService.getActiveOperation(id),
+      activeOperation: updateService.getActiveOperation(id) ?? upgradeBatchService.getQueuedOrRunningOperation(id),
       supportsFullUpgrade: updateService.supportsFullUpgrade(id),
     },
     commandReference: buildCommandReference({

--- a/server/routes/systems.ts
+++ b/server/routes/systems.ts
@@ -869,6 +869,9 @@ systems.post("/:id/reboot", async (c) => {
   const id = parseId(c.req.param("id"));
   if (!id) return c.json({ error: "Invalid system ID" }, 400);
   const result = await updateService.rebootSystem(id);
+  if (result.blocked) {
+    return c.json({ error: result.message, success: false, message: result.message, blocked: true }, 409);
+  }
   return c.json(result, result.success ? 200 : 500);
 });
 

--- a/server/routes/systems.ts
+++ b/server/routes/systems.ts
@@ -55,6 +55,18 @@ function isApiTokenRequest(c: Context<SystemsEnv>): boolean {
   return c.get("apiToken") === true;
 }
 
+function getApiTokenRestrictedSystemField(body: Record<string, unknown>): string | null {
+  const restrictedFields: Array<[string, string]> = [
+    ["scriptOverrides", "script overrides"],
+    ["detectedPkgManagers", "detected package managers"],
+    ["pkgManagerConfigs", "package manager configs"],
+  ];
+  for (const [field, label] of restrictedFields) {
+    if (body[field] !== undefined) return label;
+  }
+  return null;
+}
+
 const VALID_HOSTNAME = /^[a-zA-Z0-9]([a-zA-Z0-9._:-]*[a-zA-Z0-9])?$/;
 
 function validateSystemInput(body: Record<string, unknown>): string | null {
@@ -700,8 +712,11 @@ systems.post("/", async (c) => {
   if (!body) {
     return c.json({ error: "Invalid request body" }, 400);
   }
-  if (isApiTokenRequest(c) && body.scriptOverrides !== undefined) {
-    return c.json({ error: "API tokens cannot modify script overrides" }, 403);
+  const restrictedApiTokenField = isApiTokenRequest(c)
+    ? getApiTokenRestrictedSystemField(body)
+    : null;
+  if (restrictedApiTokenField) {
+    return c.json({ error: `API tokens cannot modify ${restrictedApiTokenField}` }, 403);
   }
   const validationError = validateSystemInput(body);
   if (validationError) return c.json({ error: validationError }, 400);
@@ -891,8 +906,11 @@ systems.put("/:id", async (c) => {
   if (!body) {
     return c.json({ error: "Invalid request body" }, 400);
   }
-  if (isApiTokenRequest(c) && body.scriptOverrides !== undefined) {
-    return c.json({ error: "API tokens cannot modify script overrides" }, 403);
+  const restrictedApiTokenField = isApiTokenRequest(c)
+    ? getApiTokenRestrictedSystemField(body)
+    : null;
+  if (restrictedApiTokenField) {
+    return c.json({ error: `API tokens cannot modify ${restrictedApiTokenField}` }, 403);
   }
   const validationError = validateSystemInput(body);
   if (validationError) return c.json({ error: validationError }, 400);

--- a/server/routes/updates.ts
+++ b/server/routes/updates.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import * as updateService from "../services/update-service";
 import * as cacheService from "../services/cache-service";
 import * as hiddenUpdateService from "../services/hidden-update-service";
+import * as upgradeBatchService from "../services/upgrade-batch-service";
 import { validatePackageName } from "../ssh/parsers/types";
 import { logger } from "../logger";
 
@@ -103,6 +104,44 @@ updates.post("/systems/check-all", async (c) => {
     logger.error("Check-all request failed", { error: String(error) });
   });
   return c.json({ status: "checking_all" });
+});
+
+updates.post("/systems/upgrade-all", async (c) => {
+  const body = asObject(await c.req.json().catch(() => null));
+  if (!body || !Array.isArray(body.items)) {
+    return c.json({ error: "items must be an array" }, 400);
+  }
+  const items = body.items.map((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+    const raw = entry as Record<string, unknown>;
+    const systemId = parseId(String(raw.systemId));
+    if (!systemId) return null;
+    const defaultUpgradeModeOverride = raw.defaultUpgradeModeOverride;
+    if (
+      defaultUpgradeModeOverride !== undefined &&
+      defaultUpgradeModeOverride !== "standard" &&
+      defaultUpgradeModeOverride !== "aggressive"
+    ) {
+      return null;
+    }
+    return {
+      systemId,
+      defaultUpgradeModeOverride,
+    };
+  });
+  if (items.some((item) => item === null)) {
+    return c.json({ error: "items must include valid systemId and defaultUpgradeModeOverride" }, 400);
+  }
+  try {
+    const { batchId } = upgradeBatchService.createUpgradeBatch(items as Array<{
+      systemId: number;
+      defaultUpgradeModeOverride?: "standard" | "aggressive";
+    }>);
+    return c.json({ status: "queued", batchId });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to start Upgrade All batch";
+    return c.json({ error: message }, message.includes("already queued or running") ? 409 : 400);
+  }
 });
 
 // Upgrade all packages on a system (async)

--- a/server/services/active-operation-store.ts
+++ b/server/services/active-operation-store.ts
@@ -1,7 +1,7 @@
 export interface ActiveOperation {
   type: "check" | "upgrade_all" | "full_upgrade_all" | "upgrade_package" | "reboot" | "package_manager_repair";
   startedAt: string;
-  phase?: "reconnecting" | "rechecking";
+  phase?: "queued" | "reconnecting" | "rechecking";
   packageName?: string;
   packageNames?: string[];
   remotePid?: number;

--- a/server/services/command-reference.ts
+++ b/server/services/command-reference.ts
@@ -364,7 +364,8 @@ export function buildCommandReference(system: CommandReferenceSystem): CommandRe
     }
   }
 
-  const reboot = getBuiltinSteps("reboot", null)[0];
+  const rebootSteps = getBuiltinSteps("reboot", null);
+  const reboot = rebootSteps[rebootSteps.length - 1];
   if (reboot) exact.push({
     id: "reboot",
     category: "reboot",

--- a/server/services/script-service.ts
+++ b/server/services/script-service.ts
@@ -15,7 +15,7 @@ import { getParser, type ParsedUpdate } from "../ssh/parsers";
 import { APT_DPKG_AUDIT_PREFIX } from "../ssh/parsers/apt";
 import type { CheckCommandResult } from "../ssh/parsers/types";
 import { sudo, validatePackageName, validatePackageNames } from "../ssh/parsers/types";
-import { getRebootCommand } from "../ssh/reboot";
+import { getProxmoxBackupGuardCommand, getRebootCommand } from "../ssh/reboot";
 import {
   SYSTEM_INFO_CMD,
   parseSystemInfo,
@@ -871,7 +871,10 @@ export function getBuiltinScripts(): ScriptDefinition[] {
       null,
       "Reboot system",
       "Reboots the remote system.",
-      [{ label: "Reboot system", command: getRebootCommand() }],
+      [
+        { label: "Pre-reboot safety checks", command: getProxmoxBackupGuardCommand() },
+        { label: "Reboot system", command: getRebootCommand() },
+      ],
     ),
   ];
 }

--- a/server/services/script-service.ts
+++ b/server/services/script-service.ts
@@ -1252,6 +1252,13 @@ export function updateScript(scriptId: string, input: Partial<ScriptDefinition>)
   const next = { ...existing, ...input, readonly: false, id: scriptId };
   const error = validateScriptInput(next);
   if (error) throw new Error(error);
+  const scopeChanged =
+    existing.type !== next.type ||
+    existing.operation !== next.operation ||
+    existing.pkgManager !== next.pkgManager;
+  if (scopeChanged && listScriptUsages(scriptId).length > 0) {
+    throw new Error("Script operation or package manager cannot be changed while assigned to systems");
+  }
   const now = new Date().toISOString().replace("T", " ").slice(0, 19);
   if (next.isDefault) clearOtherDefaults(next, parsed.id);
   const row = getDb()
@@ -1595,7 +1602,7 @@ export function resolveScript(
     .get();
   if (override) {
     const script = getScriptById(override.scriptId);
-    if (script) return script;
+    if (script && buildOperationKey(script.operation, script.pkgManager) === operationKey) return script;
   }
   const explicitDefaultId = getExplicitDefaultScriptId({
     type: pkgManager == null ? "system" : "package_manager",

--- a/server/services/script-service.ts
+++ b/server/services/script-service.ts
@@ -83,6 +83,19 @@ export interface ScriptUsage {
   operationKey: string;
 }
 
+export interface ScriptOperationProfile {
+  operation: ScriptOperation;
+  label: string;
+  allowedTypes: ScriptType[];
+  purpose: string;
+  stepBehavior: string;
+  outputConsumer: string;
+  parserBehavior: string;
+  exitCodeBehavior: string;
+  relevantPlaceholders: string[];
+  defaultStepBadge: string;
+}
+
 export interface CustomPackageManagerDefinition {
   id: number;
   builtin: boolean;
@@ -98,6 +111,7 @@ export interface ScriptListResponse {
   scripts: ScriptDefinition[];
   packageManagers: CustomPackageManagerDefinition[];
   placeholders: PlaceholderHelpEntry[];
+  operationProfiles: ScriptOperationProfile[];
 }
 
 export interface PlaceholderHelpEntry {
@@ -144,6 +158,120 @@ const SYSTEM_INFO_FIELDS = new Set<keyof SystemInfo>([
   "needsRestartingStatus",
   "needsReboot",
 ]);
+
+const OPERATION_PROFILE_ORDER: ScriptOperation[] = [
+  "detect",
+  "check_updates",
+  "repair_issue",
+  "upgrade_all",
+  "full_upgrade_all",
+  "upgrade_selected",
+  "system_info",
+  "reboot",
+];
+
+export const SCRIPT_OPERATION_PROFILES: Record<ScriptOperation, ScriptOperationProfile> = {
+  detect: {
+    operation: "detect",
+    label: "Detection",
+    allowedTypes: ["package_manager"],
+    purpose: "Determines whether a package manager is available on a remote system.",
+    stepBehavior: "Detection uses exactly one command so the result is unambiguous.",
+    outputConsumer: "The command must exit with 0 and print found on stdout to enable the manager.",
+    parserBehavior: "No update parser is used for detection output.",
+    exitCodeBehavior: "Exit code 0 with found means detected; any other result is treated as not detected.",
+    relevantPlaceholders: ["{{manager}}", "{{config.someKey}}"],
+    defaultStepBadge: "detection output",
+  },
+  check_updates: {
+    operation: "check_updates",
+    label: "Check updates",
+    allowedTypes: ["package_manager"],
+    purpose: "Refreshes package metadata and turns command output into cached update rows.",
+    stepBehavior: "Steps run in order and stop at the first failed step.",
+    outputConsumer: "Built-in parsers inspect the command results they need; custom parsers read one selected step, defaulting to the last step.",
+    parserBehavior: "Custom package managers need an update regex with packageName and newVersion groups.",
+    exitCodeBehavior: "Built-in parsers and custom success/update exit-code lists decide whether a non-zero exit code is acceptable.",
+    relevantPlaceholders: ["{{manager}}", "{{config.someKey}}", "{{sudo:COMMAND}}"],
+    defaultStepBadge: "parser input",
+  },
+  repair_issue: {
+    operation: "repair_issue",
+    label: "Repair issue",
+    allowedTypes: ["package_manager"],
+    purpose: "Runs the repair action offered for package-manager issue banners.",
+    stepBehavior: "The configured repair steps run in order and stop at the first failed step.",
+    outputConsumer: "Output is streamed live and stored in activity history; it is not parsed into update rows.",
+    parserBehavior: "No parser configuration is used.",
+    exitCodeBehavior: "A non-zero exit code marks the repair operation as failed.",
+    relevantPlaceholders: ["{{manager}}", "{{config.someKey}}", "{{sudo:COMMAND}}"],
+    defaultStepBadge: "streamed only",
+  },
+  upgrade_all: {
+    operation: "upgrade_all",
+    label: "Upgrade all",
+    allowedTypes: ["package_manager"],
+    purpose: "Installs all available updates for one package manager.",
+    stepBehavior: "Upgrade commands run as the operation body for the selected manager.",
+    outputConsumer: "Output is streamed live, stored in history, and followed by a recheck.",
+    parserBehavior: "No parser configuration is used while upgrading.",
+    exitCodeBehavior: "A non-zero exit code marks the upgrade as failed.",
+    relevantPlaceholders: ["{{manager}}", "{{config.someKey}}", "{{sudo:COMMAND}}"],
+    defaultStepBadge: "streamed only",
+  },
+  full_upgrade_all: {
+    operation: "full_upgrade_all",
+    label: "Full upgrade",
+    allowedTypes: ["package_manager"],
+    purpose: "Runs the fuller upgrade mode for package managers that support it.",
+    stepBehavior: "Full-upgrade commands run as the operation body for the selected manager.",
+    outputConsumer: "Output is streamed live, stored in history, and followed by a recheck.",
+    parserBehavior: "No parser configuration is used while upgrading.",
+    exitCodeBehavior: "A non-zero exit code marks the full upgrade as failed.",
+    relevantPlaceholders: ["{{manager}}", "{{config.someKey}}", "{{sudo:COMMAND}}"],
+    defaultStepBadge: "streamed only",
+  },
+  upgrade_selected: {
+    operation: "upgrade_selected",
+    label: "Upgrade selected",
+    allowedTypes: ["package_manager"],
+    purpose: "Upgrades the packages selected by the user.",
+    stepBehavior: "Selected package placeholders are resolved immediately before SSH execution.",
+    outputConsumer: "Output is streamed live, stored in history, and followed by a recheck.",
+    parserBehavior: "No parser configuration is used while upgrading selected packages.",
+    exitCodeBehavior: "A non-zero exit code marks the selected-package upgrade as failed.",
+    relevantPlaceholders: ["{{package}}", "{{packages}}", "{{quotedPackage}}", "{{quotedPackages}}", "{{manager}}", "{{config.someKey}}", "{{sudo:COMMAND}}"],
+    defaultStepBadge: "streamed only",
+  },
+  system_info: {
+    operation: "system_info",
+    label: "System info",
+    allowedTypes: ["system"],
+    purpose: "Collects OS, kernel, uptime, resource, boot, and reboot-required details.",
+    stepBehavior: "System-info steps run in order and their output is consumed by the configured mapping mode.",
+    outputConsumer: "The built-in parser reads dashboard sections; custom section mapping reads named output sections into system fields.",
+    parserBehavior: "Use built-in mode for copied standard scripts, or sectioned mode for custom output.",
+    exitCodeBehavior: "A non-zero exit code marks system-info collection as failed.",
+    relevantPlaceholders: ["{{sudo:COMMAND}}"],
+    defaultStepBadge: "system fields",
+  },
+  reboot: {
+    operation: "reboot",
+    label: "Reboot",
+    allowedTypes: ["system"],
+    purpose: "Reboots the remote system after any configured safety checks pass.",
+    stepBehavior: "Reboot steps run in order and stop before later steps when an earlier step fails.",
+    outputConsumer: "Output is streamed live and stored in activity history; it is not parsed into system fields or update rows.",
+    parserBehavior: "No parser configuration is used.",
+    exitCodeBehavior: "A non-zero exit code before the reboot command prevents later steps from running.",
+    relevantPlaceholders: ["{{sudo:COMMAND}}"],
+    defaultStepBadge: "streamed only",
+  },
+};
+
+export function getScriptOperationProfiles(): ScriptOperationProfile[] {
+  return OPERATION_PROFILE_ORDER.map((operation) => SCRIPT_OPERATION_PROFILES[operation]);
+}
 
 export const PLACEHOLDER_HELP: PlaceholderHelpEntry[] = [
   { name: "{{package}}", description: "The first selected package name, validated before execution.", example: "apt-get install --only-upgrade -y {{package}}" },
@@ -973,6 +1101,7 @@ export function listScripts(): ScriptListResponse {
     scripts,
     packageManagers,
     placeholders: buildPlaceholderHelp(),
+    operationProfiles: getScriptOperationProfiles(),
   };
 }
 
@@ -1033,6 +1162,9 @@ function validateScriptInput(input: Partial<ScriptDefinition>): string | null {
   if (input.steps.length > MAX_SCRIPT_STEPS) {
     return `steps must include at most ${MAX_SCRIPT_STEPS} commands`;
   }
+  if (input.operation === "detect" && input.steps.length !== 1) {
+    return "detection scripts must include exactly one step";
+  }
   for (const step of input.steps) {
     if (!isRecord(step)) return "each step must be an object";
     if (
@@ -1046,6 +1178,15 @@ function validateScriptInput(input: Partial<ScriptDefinition>): string | null {
       return `each step needs a label and command (command max ${MAX_STEP_COMMAND_LENGTH} chars)`;
     }
   }
+  const parserConfigError = validateParserConfig(input.parserConfig);
+  if (parserConfigError) return parserConfigError;
+  if (
+    input.operation === "check_updates" &&
+    input.parserConfig?.parseStep !== undefined &&
+    input.parserConfig.parseStep >= input.steps.length
+  ) {
+    return "parserConfig.parseStep must reference an existing step";
+  }
   if (
     input.sourceScriptId !== undefined &&
     input.sourceScriptId !== null &&
@@ -1053,7 +1194,7 @@ function validateScriptInput(input: Partial<ScriptDefinition>): string | null {
   ) {
     return "sourceScriptId must be a valid script ID";
   }
-  return validateParserConfig(input.parserConfig) || validateSystemInfoConfig(input.systemInfoConfig);
+  return validateSystemInfoConfig(input.systemInfoConfig);
 }
 
 function defaultScopeCondition(input: Pick<ScriptDefinition, "type" | "operation" | "pkgManager">) {

--- a/server/services/system-service.ts
+++ b/server/services/system-service.ts
@@ -257,19 +257,19 @@ export function createUpgradeGroup(name: string): number {
     throw new Error("Group name is required (max 100 chars)");
   }
   const storedUngroupedSortOrder = getStoredUngroupedUpgradeGroupSortOrder();
-  const maxRealGroupSortOrder = getDb()
-    .select({ value: sql<number>`COALESCE(MAX(${upgradeGroups.sortOrder}), -1)` })
+  const minRealGroupSortOrder = getDb()
+    .select({ value: sql<number>`MIN(${upgradeGroups.sortOrder})` })
     .from(upgradeGroups)
-    .get()?.value ?? -1;
-  const maxSortOrder =
-    storedUngroupedSortOrder === null
-      ? maxRealGroupSortOrder
-      : Math.max(storedUngroupedSortOrder, maxRealGroupSortOrder);
+    .get()?.value;
+  const firstSortOrder = Math.min(
+    storedUngroupedSortOrder ?? DEFAULT_UNGROUPED_UPGRADE_SORT_ORDER,
+    minRealGroupSortOrder ?? DEFAULT_UNGROUPED_UPGRADE_SORT_ORDER,
+  );
   const inserted = getDb()
     .insert(upgradeGroups)
     .values({
       name: trimmedName,
-      sortOrder: maxSortOrder + 1,
+      sortOrder: firstSortOrder - 1,
     })
     .returning({ id: upgradeGroups.id })
     .get();

--- a/server/services/system-service.ts
+++ b/server/services/system-service.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq, inArray, ne, sql } from "drizzle-orm";
 import { getDb } from "../db";
-import { systems } from "../db/schema";
+import { settings, systems, upgradeGroups } from "../db/schema";
 import { getEncryptor } from "../security";
 import { resolveSystemCredential } from "./credential-service";
 import * as cacheService from "./cache-service";
@@ -25,6 +25,8 @@ const SYSTEM_CONNECTION_UNIQUE_CONSTRAINT =
   "systems.hostname, systems.port, systems.username";
 const SYSTEM_CONNECTION_UNIQUE_INDEX = "systems_connection_identity_idx";
 export const MAX_PROXY_JUMP_DEPTH = 10;
+const UPGRADE_UNGROUPED_SORT_ORDER_KEY = "upgrade_ungrouped_sort_order";
+const DEFAULT_UNGROUPED_UPGRADE_SORT_ORDER = 1_000_000;
 
 export class DuplicateSystemConnectionError extends Error {
   constructor() {
@@ -207,6 +209,134 @@ export function listVisibleSystems() {
     .where(eq(systems.hidden, 0))
     .orderBy(asc(systems.sortOrder), asc(systems.name), asc(systems.id))
     .all();
+}
+
+export function listUpgradeGroups() {
+  return getDb()
+    .select()
+    .from(upgradeGroups)
+    .orderBy(asc(upgradeGroups.sortOrder), asc(upgradeGroups.name), asc(upgradeGroups.id))
+    .all();
+}
+
+function getStoredUngroupedUpgradeGroupSortOrder(): number | null {
+  const value = getDb()
+    .select({ value: settings.value })
+    .from(settings)
+    .where(eq(settings.key, UPGRADE_UNGROUPED_SORT_ORDER_KEY))
+    .get()?.value;
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+export function getUngroupedUpgradeGroupSortOrder(): number {
+  return getStoredUngroupedUpgradeGroupSortOrder() ?? DEFAULT_UNGROUPED_UPGRADE_SORT_ORDER;
+}
+
+function setUngroupedUpgradeGroupSortOrder(sortOrder: number): void {
+  getDb()
+    .insert(settings)
+    .values({
+      key: UPGRADE_UNGROUPED_SORT_ORDER_KEY,
+      value: String(sortOrder),
+      description: "Sort position of the implicit Ungrouped upgrade group",
+    })
+    .onConflictDoUpdate({
+      target: settings.key,
+      set: {
+        value: String(sortOrder),
+        updatedAt: new Date().toISOString().replace("T", " ").slice(0, 19),
+      },
+    })
+    .run();
+}
+
+export function createUpgradeGroup(name: string): number {
+  const trimmedName = name.trim();
+  if (!trimmedName || trimmedName.length > 100) {
+    throw new Error("Group name is required (max 100 chars)");
+  }
+  const storedUngroupedSortOrder = getStoredUngroupedUpgradeGroupSortOrder();
+  const maxRealGroupSortOrder = getDb()
+    .select({ value: sql<number>`COALESCE(MAX(${upgradeGroups.sortOrder}), -1)` })
+    .from(upgradeGroups)
+    .get()?.value ?? -1;
+  const maxSortOrder =
+    storedUngroupedSortOrder === null
+      ? maxRealGroupSortOrder
+      : Math.max(storedUngroupedSortOrder, maxRealGroupSortOrder);
+  const inserted = getDb()
+    .insert(upgradeGroups)
+    .values({
+      name: trimmedName,
+      sortOrder: maxSortOrder + 1,
+    })
+    .returning({ id: upgradeGroups.id })
+    .get();
+  return inserted.id;
+}
+
+export function updateUpgradeGroup(groupId: number, name: string): void {
+  const trimmedName = name.trim();
+  if (!trimmedName || trimmedName.length > 100) {
+    throw new Error("Group name is required (max 100 chars)");
+  }
+  const result = getDb()
+    .update(upgradeGroups)
+    .set({
+      name: trimmedName,
+      updatedAt: new Date().toISOString().replace("T", " ").slice(0, 19),
+    })
+    .where(eq(upgradeGroups.id, groupId))
+    .run();
+  if (result.changes === 0) throw new Error("Upgrade group not found");
+}
+
+export function deleteUpgradeGroup(groupId: number): void {
+  const db = getDb();
+  const existing = db
+    .select({ id: upgradeGroups.id })
+    .from(upgradeGroups)
+    .where(eq(upgradeGroups.id, groupId))
+    .get();
+  if (!existing) throw new Error("Upgrade group not found");
+  db.update(systems)
+    .set({
+      upgradeGroupId: null,
+      updatedAt: new Date().toISOString().replace("T", " ").slice(0, 19),
+    })
+    .where(eq(systems.upgradeGroupId, groupId))
+    .run();
+  db.delete(upgradeGroups).where(eq(upgradeGroups.id, groupId)).run();
+}
+
+export function reorderUpgradeGroups(groupKeys: Array<number | "ungrouped">): void {
+  const existingIds = listUpgradeGroups().map((group) => group.id);
+  const ungroupedCount = groupKeys.filter((key) => key === "ungrouped").length;
+  const groupIds = groupKeys.filter((key): key is number => typeof key === "number");
+  if (ungroupedCount !== 1) {
+    throw new Error("Group order must include Ungrouped exactly once");
+  }
+  if (groupIds.length !== existingIds.length) {
+    throw new Error("Group order must include every saved group exactly once");
+  }
+  if (new Set(groupIds).size !== groupIds.length) {
+    throw new Error("Group order contains duplicate IDs");
+  }
+  if (!existingIds.every((id) => groupIds.includes(id))) {
+    throw new Error("Group order contains unknown IDs");
+  }
+  for (const [sortOrder, key] of groupKeys.entries()) {
+    if (key === "ungrouped") {
+      setUngroupedUpgradeGroupSortOrder(sortOrder);
+    } else {
+      getDb()
+        .update(upgradeGroups)
+        .set({ sortOrder, updatedAt: new Date().toISOString().replace("T", " ").slice(0, 19) })
+        .where(eq(upgradeGroups.id, key))
+        .run();
+    }
+  }
 }
 
 export function isSystemVisible(systemId: number): boolean {
@@ -552,6 +682,65 @@ export function reorderSystemUpgradeOrder(systemIds: number[]): void {
     db.update(systems)
       .set({ upgradeOrder: index + 1 })
       .where(eq(systems.id, id))
+      .run();
+  }
+}
+
+export function moveSystemsForUpgradeGroups(
+  items: Array<{ systemId: number; groupId: number | null; upgradeOrder: number }>
+): void {
+  if (items.length === 0) throw new Error("At least one system is required");
+  const systemIds = items.map((item) => item.systemId);
+  if (new Set(systemIds).size !== systemIds.length) {
+    throw new Error("System list contains duplicate IDs");
+  }
+  if (items.some((item) => !Number.isInteger(item.systemId) || item.systemId <= 0)) {
+    throw new Error("System IDs must be positive integers");
+  }
+  if (items.some((item) => item.groupId !== null && (!Number.isInteger(item.groupId) || item.groupId <= 0))) {
+    throw new Error("Group IDs must be positive integers or null");
+  }
+  if (items.some((item) => !Number.isInteger(item.upgradeOrder) || item.upgradeOrder <= 0)) {
+    throw new Error("Upgrade order values must be positive integers");
+  }
+
+  const db = getDb();
+  const existingSystemIds = new Set(
+    db
+      .select({ id: systems.id })
+      .from(systems)
+      .where(inArray(systems.id, systemIds))
+      .all()
+      .map((system) => system.id)
+  );
+  if (!systemIds.every((id) => existingSystemIds.has(id))) {
+    throw new Error("System list contains unknown IDs");
+  }
+
+  const groupIds = Array.from(new Set(items.map((item) => item.groupId).filter((id): id is number => id !== null)));
+  if (groupIds.length > 0) {
+    const existingGroupIds = new Set(
+      db
+        .select({ id: upgradeGroups.id })
+        .from(upgradeGroups)
+        .where(inArray(upgradeGroups.id, groupIds))
+        .all()
+        .map((group) => group.id)
+    );
+    if (!groupIds.every((id) => existingGroupIds.has(id))) {
+      throw new Error("System list contains unknown group IDs");
+    }
+  }
+
+  const now = new Date().toISOString().replace("T", " ").slice(0, 19);
+  for (const item of items) {
+    db.update(systems)
+      .set({
+        upgradeGroupId: item.groupId,
+        upgradeOrder: item.upgradeOrder,
+        updatedAt: now,
+      })
+      .where(eq(systems.id, item.systemId))
       .run();
   }
 }

--- a/server/services/update-service.ts
+++ b/server/services/update-service.ts
@@ -46,6 +46,7 @@ import {
 type VisibleCachedUpdate = ReturnType<typeof hiddenUpdateService.getVisibleCachedUpdates>[number];
 export type DefaultUpgradeModeOverride = "standard" | "aggressive";
 type OperationResult = { success: boolean; output: string; warning?: boolean; cancelled?: boolean };
+type RebootResult = { success: boolean; message: string; blocked?: boolean };
 
 function withDefaultUpgradeModeOverride(
   configs: PackageManagerConfigs | null,
@@ -1878,9 +1879,23 @@ export async function applyUpgradePackages(
   });
 }
 
-export async function rebootSystem(
-  systemId: number
-): Promise<{ success: boolean; message: string }> {
+const PRE_REBOOT_SAFETY_CHECKS_LABEL = "Pre-reboot safety checks";
+
+function isProxmoxBackupGuardStep(step: { label: string | null }): boolean {
+  return step.label === PRE_REBOOT_SAFETY_CHECKS_LABEL;
+}
+
+function normalizeProxmoxBackupGuardMessage(output: string): string {
+  const lines = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const blockedLine = lines.find((line) => line.startsWith("Reboot blocked:"));
+  if (blockedLine) return blockedLine;
+  return "Reboot blocked: could not verify Proxmox backup activity.";
+}
+
+export async function rebootSystem(systemId: number): Promise<RebootResult> {
   return withLock(systemId, async () => {
     const now = getCurrentTimestamp();
     setActiveOperation(systemId, { type: "reboot", startedAt: now });
@@ -1893,11 +1908,17 @@ export async function rebootSystem(
       const sshManager = getSSHManager();
       const signal = getCancellationSignal(systemId);
       const sudoPassword = systemService.getSudoPassword(system as Record<string, unknown>);
-      const cmd = resolveRuntimeSteps({ systemId, operation: "reboot" })[0]?.command;
-      if (!cmd) return { success: false, message: "No reboot script configured" };
-      const stepStartedAt = getCurrentTimestamp();
-      const histId = insertStartedEntry(systemId, "reboot", "system", cmd, stepStartedAt);
-      outputStream.publish(systemId, { type: "started", command: cmd, pkgManager: "system", startedAt: stepStartedAt });
+      const steps = resolveRuntimeSteps({ systemId, operation: "reboot" });
+      if (!steps.length) return { success: false, message: "No reboot script configured" };
+      const historyStartedAt = getCurrentTimestamp();
+      const histId = insertStartedEntry(
+        systemId,
+        "reboot",
+        "system",
+        steps.map((step) => step.command).join(" && "),
+        historyStartedAt,
+      );
+      const activitySteps: ActivityStep[] = [];
 
       let conn;
       try {
@@ -1906,40 +1927,49 @@ export async function rebootSystem(
           systemId,
         });
         throwIfActiveOperationCancelled(systemId);
-        let streamedOutput = "";
-        const result = await sshManager.runCommand(conn, cmd, 30, sudoPassword, (chunk, stream) => {
-          streamedOutput += chunk;
-          outputStream.publish(systemId, { type: "output", data: chunk, stream });
-        }, signal);
-        const stepCompletedAt = getCurrentTimestamp();
 
-        if (isCancelledResult(result.exitCode)) {
-          finishEntry(histId, "cancelled", {
-            steps: createSingleStepHistory({
-              label: null,
+        for (const step of steps) {
+          const cmd = step.command;
+          const label = step.label || null;
+          const stepStartedAt = getCurrentTimestamp();
+          outputStream.publish(systemId, { type: "started", command: cmd, pkgManager: "system", startedAt: stepStartedAt });
+          if (label) outputStream.publish(systemId, { type: "phase", phase: label });
+
+          let streamedOutput = "";
+          const result = await sshManager.runCommand(conn, cmd, 30, sudoPassword, (chunk, stream) => {
+            streamedOutput += chunk;
+            outputStream.publish(systemId, { type: "output", data: chunk, stream });
+          }, signal);
+          const stepCompletedAt = getCurrentTimestamp();
+          const combinedOutput = streamedOutput || result.stdout || result.stderr;
+
+          if (isCancelledResult(result.exitCode)) {
+            const message = "Operation cancelled";
+            activitySteps.push(createActivityStep({
+              label,
               pkgManager: "system",
               command: cmd,
-              output: streamedOutput || result.stdout || result.stderr,
-              error: "Operation cancelled",
+              output: combinedOutput,
+              error: message,
               status: "cancelled",
               startedAt: stepStartedAt,
               completedAt: stepCompletedAt,
-            }),
-            error: "Operation cancelled",
-          });
-          outputStream.publish(systemId, { type: "warning", message: "Operation cancelled" });
-          outputStream.publish(systemId, { type: "done", success: false, completedAt: getCurrentTimestamp() });
-          return { success: false, message: "Operation cancelled" };
-        }
+            }));
+            finishEntry(histId, "cancelled", {
+              steps: activitySteps,
+              error: message,
+            });
+            outputStream.publish(systemId, { type: "warning", message });
+            outputStream.publish(systemId, { type: "done", success: false, completedAt: getCurrentTimestamp() });
+            return { success: false, message };
+          }
 
-        if (result.exitCode !== 0) {
-          const errorText = result.stderr || result.stdout || `reboot exited with code ${result.exitCode}`;
-          if (isExpectedRebootDisconnect(errorText)) {
-            const outputText = streamedOutput || result.stdout || "Reboot command sent (connection closed)";
-            systemService.markUnreachable(systemId);
-            finishEntry(histId, "success", {
-              steps: createSingleStepHistory({
-                label: null,
+          if (result.exitCode !== 0) {
+            const errorText = result.stderr || result.stdout || combinedOutput || `reboot exited with code ${result.exitCode}`;
+            if (!isProxmoxBackupGuardStep(step) && isExpectedRebootDisconnect(errorText)) {
+              const outputText = combinedOutput || "Reboot command sent (connection closed)";
+              activitySteps.push(createActivityStep({
+                label,
                 pkgManager: "system",
                 command: cmd,
                 output: outputText,
@@ -1947,62 +1977,77 @@ export async function rebootSystem(
                 status: "success",
                 startedAt: stepStartedAt,
                 completedAt: stepCompletedAt,
-              }),
-              output: outputText,
-            });
-            outputStream.publish(systemId, { type: "done", success: true, completedAt: getCurrentTimestamp() });
-            return { success: true, message: "Reboot command sent" };
-          }
+              }));
+              systemService.markUnreachable(systemId);
+              finishEntry(histId, "success", {
+                steps: activitySteps,
+                output: outputText,
+              });
+              outputStream.publish(systemId, { type: "done", success: true, completedAt: getCurrentTimestamp() });
+              return { success: true, message: "Reboot command sent" };
+            }
 
-          finishEntry(histId, "failed", {
-            steps: createSingleStepHistory({
-              label: null,
+            const blocked = isProxmoxBackupGuardStep(step);
+            const message = blocked
+              ? normalizeProxmoxBackupGuardMessage(errorText)
+              : `Reboot failed: ${errorText}`;
+            activitySteps.push(createActivityStep({
+              label,
               pkgManager: "system",
               command: cmd,
-              output: streamedOutput || result.stdout || result.stderr,
-              error: errorText,
+              output: combinedOutput,
+              error: message,
               status: "failed",
               startedAt: stepStartedAt,
               completedAt: stepCompletedAt,
-            }),
-            error: errorText,
-          });
-          outputStream.publish(systemId, { type: "error", message: errorText });
-          outputStream.publish(systemId, { type: "done", success: false, completedAt: getCurrentTimestamp() });
-          return { success: false, message: `Reboot failed: ${errorText}` };
-        }
+            }));
+            finishEntry(histId, "failed", {
+              steps: activitySteps,
+              output: combinedOutput,
+              error: message,
+            });
+            outputStream.publish(systemId, { type: "error", message });
+            outputStream.publish(systemId, { type: "done", success: false, completedAt: getCurrentTimestamp() });
+            return { success: false, message, blocked };
+          }
 
-        // Reboot succeeded or the connection was dropped (expected)
-        systemService.markUnreachable(systemId);
-        finishEntry(histId, "success", {
-          steps: createSingleStepHistory({
-            label: null,
+          activitySteps.push(createActivityStep({
+            label,
             pkgManager: "system",
             command: cmd,
-            output: streamedOutput || result.stdout || "Reboot command sent",
+            output: combinedOutput,
             error: null,
             status: "success",
             startedAt: stepStartedAt,
             completedAt: stepCompletedAt,
-          }),
-          output: result.stdout || "Reboot command sent",
+          }));
+        }
+
+        systemService.markUnreachable(systemId);
+        finishEntry(histId, "success", {
+          steps: activitySteps,
+          output: "Reboot command sent",
         });
         outputStream.publish(systemId, { type: "done", success: true, completedAt: getCurrentTimestamp() });
         return { success: true, message: "Reboot command sent" };
       } catch (e) {
         if (isOperationCancelledError(e)) {
+          const step = steps[Math.min(activitySteps.length, steps.length - 1)];
           const stepCompletedAt = getCurrentTimestamp();
-          finishEntry(histId, "cancelled", {
-            steps: createSingleStepHistory({
-              label: null,
+          if (step) {
+            activitySteps.push(createActivityStep({
+              label: step.label || null,
               pkgManager: "system",
-              command: cmd,
+              command: step.command,
               output: null,
               error: e.message,
               status: "cancelled",
-              startedAt: stepStartedAt,
+              startedAt: stepCompletedAt,
               completedAt: stepCompletedAt,
-            }),
+            }));
+          }
+          finishEntry(histId, "cancelled", {
+            steps: activitySteps,
             error: e.message,
           });
           outputStream.publish(systemId, { type: "warning", message: e.message });
@@ -2011,36 +2056,62 @@ export async function rebootSystem(
         }
         const errMsg = String(e);
         const stepCompletedAt = getCurrentTimestamp();
-        // A closed connection after reboot is expected
+        const currentStep = steps[Math.min(activitySteps.length, steps.length - 1)];
+        if (currentStep && isProxmoxBackupGuardStep(currentStep)) {
+          const message = "Reboot blocked: could not verify Proxmox backup activity.";
+          activitySteps.push(createActivityStep({
+            label: currentStep.label || null,
+            pkgManager: "system",
+            command: currentStep.command,
+            output: null,
+            error: message,
+            status: "failed",
+            startedAt: stepCompletedAt,
+            completedAt: stepCompletedAt,
+          }));
+          finishEntry(histId, "failed", {
+            steps: activitySteps,
+            error: message,
+          });
+          outputStream.publish(systemId, { type: "error", message });
+          outputStream.publish(systemId, { type: "done", success: false, completedAt: getCurrentTimestamp() });
+          return { success: false, message, blocked: true };
+        }
         if (isExpectedRebootDisconnect(errMsg)) {
-          systemService.markUnreachable(systemId);
-          finishEntry(histId, "success", {
-            steps: createSingleStepHistory({
-              label: null,
+          if (currentStep) {
+            activitySteps.push(createActivityStep({
+              label: currentStep.label || null,
               pkgManager: "system",
-              command: cmd,
+              command: currentStep.command,
               output: "Reboot command sent (connection closed)",
               error: null,
               status: "success",
-              startedAt: stepStartedAt,
+              startedAt: stepCompletedAt,
               completedAt: stepCompletedAt,
-            }),
+            }));
+          }
+          systemService.markUnreachable(systemId);
+          finishEntry(histId, "success", {
+            steps: activitySteps,
             output: "Reboot command sent (connection closed)",
           });
           outputStream.publish(systemId, { type: "done", success: true, completedAt: getCurrentTimestamp() });
           return { success: true, message: "Reboot command sent" };
         }
-        finishEntry(histId, "failed", {
-          steps: createSingleStepHistory({
-            label: null,
+        if (currentStep) {
+          activitySteps.push(createActivityStep({
+            label: currentStep.label || null,
             pkgManager: "system",
-            command: cmd,
+            command: currentStep.command,
             output: null,
             error: errMsg,
             status: "failed",
-            startedAt: stepStartedAt,
+            startedAt: stepCompletedAt,
             completedAt: stepCompletedAt,
-          }),
+          }));
+        }
+        finishEntry(histId, "failed", {
+          steps: activitySteps,
           error: errMsg,
         });
         outputStream.publish(systemId, { type: "error", message: errMsg });

--- a/server/services/update-service.ts
+++ b/server/services/update-service.ts
@@ -48,6 +48,40 @@ export type DefaultUpgradeModeOverride = "standard" | "aggressive";
 type OperationResult = { success: boolean; output: string; warning?: boolean; cancelled?: boolean };
 type RebootResult = { success: boolean; message: string; blocked?: boolean };
 
+export interface UpgradeAllCommandSnapshot {
+  systemId: number;
+  pkgManagers: string[];
+  command: string | null;
+  pkgManager: string;
+  commands: Array<{ pkgManager: string; command: string }>;
+}
+
+interface QueuedUpgradeResumeState {
+  historyId: number;
+  pkgManager: string;
+  command: string;
+  persistentInfo: PersistentCommandInfo;
+  preUpgradeUpdateCount: number;
+}
+
+interface UpgradeAllExecutionOptions {
+  defaultUpgradeModeOverride?: DefaultUpgradeModeOverride;
+  queuedHistoryId?: number;
+  resume?: QueuedUpgradeResumeState;
+  onStepStarted?: (input: {
+    historyId: number;
+    pkgManager: string;
+    command: string;
+    preUpgradeUpdateCount: number;
+  }) => void;
+  onPersistentInfo?: (input: {
+    historyId: number;
+    pkgManager: string;
+    command: string;
+    info: PersistentCommandInfo;
+  }) => void;
+}
+
 function withDefaultUpgradeModeOverride(
   configs: PackageManagerConfigs | null,
   override?: DefaultUpgradeModeOverride,
@@ -218,6 +252,7 @@ interface ReconnectionResult {
   stdout: string;
   stderr: string;
   serverRebooted: boolean;
+  persistentInfo?: PersistentCommandInfo;
 }
 
 export type ActivityStepStatus = "success" | "warning" | "failed" | "started" | "cancelled";
@@ -345,6 +380,54 @@ export function getConfiguredUpgradeBehaviorDescriptions(systemId: number): stri
   if (!system) return [];
   const pkgManagers = systemService.getActivePkgManagers(system);
   return describeUpgradeBehaviors(pkgManagers, getSystemPackageManagerConfigs(system));
+}
+
+function getUpgradeAllPkgManagers(systemId: number, system: { pkgManager?: string | null }): string[] {
+  const db = getDb();
+  const cachedManagers = db
+    .selectDistinct({ pkgManager: updateCache.pkgManager })
+    .from(updateCache)
+    .where(eq(updateCache.systemId, systemId))
+    .all()
+    .map((r) => r.pkgManager);
+
+  return cachedManagers.length > 0
+    ? cachedManagers
+    : system.pkgManager
+      ? [system.pkgManager]
+      : [];
+}
+
+export function getUpgradeAllCommandSnapshot(
+  systemId: number,
+  options?: { defaultUpgradeModeOverride?: DefaultUpgradeModeOverride },
+): UpgradeAllCommandSnapshot {
+  const system = systemService.getSystem(systemId);
+  if (!system) {
+    return { systemId, pkgManagers: [], command: null, pkgManager: "system", commands: [] };
+  }
+  const pkgManagerConfigs = withDefaultUpgradeModeOverride(
+    getSystemPackageManagerConfigs(system),
+    options?.defaultUpgradeModeOverride,
+  );
+  const pkgManagers = getUpgradeAllPkgManagers(systemId, system);
+  const commands = pkgManagers.flatMap((pmName) => {
+    const steps = resolveRuntimeSteps({
+      systemId,
+      operation: "upgrade_all",
+      pkgManager: pmName,
+      pkgManagerConfig: getManagerConfig(pkgManagerConfigs, pmName),
+    });
+    const command = steps[0]?.command;
+    return command ? [{ pkgManager: pmName, command }] : [];
+  });
+  return {
+    systemId,
+    pkgManagers,
+    command: commands.map((entry) => entry.command).join(" && ") || null,
+    pkgManager: commands.map((entry) => entry.pkgManager).join(",") || pkgManagers.join(",") || "system",
+    commands,
+  };
 }
 
 interface SelectedPackageUpgradeResolution {
@@ -671,6 +754,26 @@ function insertStartedEntry(
     .get();
   pruneHistoryForSystem(systemId);
   return result.id;
+}
+
+function markEntryStarted(
+  id: number,
+  pkgManager: string,
+  command: string,
+  startedAt = getCurrentTimestamp(),
+): void {
+  getDb().update(updateHistory)
+    .set({
+      pkgManager,
+      status: "started",
+      command: sanitizeCommand(command),
+      startedAt,
+      completedAt: null,
+      output: null,
+      error: null,
+    })
+    .where(eq(updateHistory.id, id))
+    .run();
 }
 
 /** Update an existing history row to its final status. */
@@ -1162,7 +1265,7 @@ export async function solvePackageManagerIssue(
 
 export async function applyUpgradeAll(
   systemId: number,
-  options?: { defaultUpgradeModeOverride?: DefaultUpgradeModeOverride },
+  options?: UpgradeAllExecutionOptions,
 ): Promise<OperationResult> {
   return withLock(systemId, async () => {
     const now = getCurrentTimestamp();
@@ -1179,24 +1282,15 @@ export async function applyUpgradeAll(
       options?.defaultUpgradeModeOverride,
     );
 
-    // Collect all distinct package managers from the cached updates
     const db = getDb();
-    const cachedManagers = db
-      .selectDistinct({ pkgManager: updateCache.pkgManager })
-      .from(updateCache)
-      .where(eq(updateCache.systemId, systemId))
-      .all()
-      .map((r) => r.pkgManager);
-
-    // Fall back to stored primary manager if cache is empty
-    const pkgManagers =
-      cachedManagers.length > 0
-        ? cachedManagers
-        : system.pkgManager
-          ? [system.pkgManager]
-          : [];
+    const pkgManagers = getUpgradeAllPkgManagers(systemId, system);
 
     if (!pkgManagers.length) {
+      if (options?.queuedHistoryId) {
+        finishEntry(options.queuedHistoryId, "failed", {
+          error: "No package manager detected",
+        });
+      }
       return { success: false, output: "No package manager detected" };
     }
 
@@ -1211,12 +1305,19 @@ export async function applyUpgradeAll(
     let conn;
     try {
       throwIfActiveOperationCancelled(systemId);
-      conn = await sshManager.connect(system as Record<string, unknown>, {
-        systemId,
-      });
-      throwIfActiveOperationCancelled(systemId);
+      if (!options?.resume) {
+        conn = await sshManager.connect(system as Record<string, unknown>, {
+          systemId,
+        });
+        throwIfActiveOperationCancelled(systemId);
+      }
 
-      for (const pmName of pkgManagers) {
+      const resumeIndex = options?.resume
+        ? pkgManagers.findIndex((pmName) => pmName === options.resume?.pkgManager)
+        : -1;
+      const startIndex = resumeIndex >= 0 ? resumeIndex : 0;
+
+      for (const pmName of pkgManagers.slice(startIndex)) {
         throwIfActiveOperationCancelled(systemId);
         const steps = resolveRuntimeSteps({
           systemId,
@@ -1226,9 +1327,35 @@ export async function applyUpgradeAll(
         });
         const cmd = steps[0]?.command;
         if (!cmd) continue;
+        const isResumeStep = options?.resume?.pkgManager === pmName;
+        if (!isResumeStep && !conn) {
+          conn = await sshManager.connect(system as Record<string, unknown>, {
+            systemId,
+          });
+          throwIfActiveOperationCancelled(systemId);
+        }
         allCommands.push(cmd);
         const stepStartedAt = getCurrentTimestamp();
-        const histId = insertStartedEntry(systemId, "upgrade_all", pmName, cmd, stepStartedAt);
+        const histId =
+          isResumeStep
+            ? options.resume!.historyId
+            : options?.queuedHistoryId && allCommands.length === 1 && startIndex === 0
+              ? options.queuedHistoryId
+              : insertStartedEntry(systemId, "upgrade_all", pmName, cmd, stepStartedAt);
+        if (isResumeStep || histId === options?.queuedHistoryId) {
+          markEntryStarted(histId, pmName, cmd, stepStartedAt);
+        }
+        const preCount = db
+          .select()
+          .from(updateCache)
+          .where(eq(updateCache.systemId, systemId))
+          .all().length;
+        options?.onStepStarted?.({
+          historyId: histId,
+          pkgManager: pmName,
+          command: cmd,
+          preUpgradeUpdateCount: preCount,
+        });
         outputStream.publish(systemId, { type: "started", command: cmd, pkgManager: pmName, startedAt: stepStartedAt });
         let streamedOutput = "";
 
@@ -1237,17 +1364,32 @@ export async function applyUpgradeAll(
           outputStream.publish(systemId, { type: "output", data: chunk, stream });
         };
 
-        const result = await sshManager.runPersistentCommand(
-          conn!,
-          cmd,
-          3600,
-          sudoPassword,
-          onDataCb,
-          {
-            signal,
-            onPersistentInfo: (info) => setActiveOperationPersistentInfo(systemId, info),
-          },
-        );
+        const result = isResumeStep
+          ? await attemptReconnection(
+              systemId,
+              options.resume!.persistentInfo,
+              options.resume!.preUpgradeUpdateCount,
+              onDataCb,
+            )
+          : await sshManager.runPersistentCommand(
+              conn!,
+              cmd,
+              3600,
+              sudoPassword,
+              onDataCb,
+              {
+                signal,
+                onPersistentInfo: (info) => {
+                  setActiveOperationPersistentInfo(systemId, info);
+                  options?.onPersistentInfo?.({
+                    historyId: histId,
+                    pkgManager: pmName,
+                    command: cmd,
+                    info,
+                  });
+                },
+              },
+            );
 
         let { stdout, stderr, exitCode } = result;
 
@@ -1277,12 +1419,6 @@ export async function applyUpgradeAll(
           // Connection lost — attempt reconnection
           try { sshManager.disconnect(conn!); } catch {}
           conn = undefined;
-
-          const preCount = db
-            .select()
-            .from(updateCache)
-            .where(eq(updateCache.systemId, systemId))
-            .all().length;
 
           const reconResult = await attemptReconnection(
             systemId,
@@ -1331,6 +1467,14 @@ export async function applyUpgradeAll(
 
         // If connection was lost, can't continue with remaining package managers
         if (reconnectionUsed) break;
+      }
+
+      if (allCommands.length === 0 && options?.queuedHistoryId) {
+        finishEntry(options.queuedHistoryId, "failed", {
+          error: "No upgrade command available",
+        });
+        outputStream.publish(systemId, { type: "done", success: false, completedAt: getCurrentTimestamp() });
+        return { success: false, output: "No upgrade command available" };
       }
 
       // Re-check after upgrade (skip if reconnection already ran one)

--- a/server/services/upgrade-batch-service.ts
+++ b/server/services/upgrade-batch-service.ts
@@ -1,0 +1,367 @@
+import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
+import { getDb } from "../db";
+import { systems, updateHistory, upgradeBatchItems, upgradeBatches, upgradeGroups } from "../db/schema";
+import { sanitizeCommand, sanitizeOutput } from "../utils/sanitize";
+import * as systemService from "./system-service";
+import * as updateService from "./update-service";
+import type { DefaultUpgradeModeOverride } from "./update-service";
+import type { PersistentCommandInfo } from "../ssh/connection";
+import { logger } from "../logger";
+
+type BatchStatus = "queued" | "running" | "success" | "warning" | "failed" | "cancelled";
+type ItemStatus = "queued" | "running" | "success" | "warning" | "failed" | "cancelled";
+
+interface BatchItemInput {
+  systemId: number;
+  defaultUpgradeModeOverride?: DefaultUpgradeModeOverride;
+}
+
+function now(): string {
+  return new Date().toISOString().replace("T", " ").replace("Z", "");
+}
+
+function terminalStatuses(): ItemStatus[] {
+  return ["success", "warning", "failed", "cancelled"];
+}
+
+function isTerminal(status: string): boolean {
+  return terminalStatuses().includes(status as ItemStatus);
+}
+
+function getActiveBatch() {
+  return getDb()
+    .select()
+    .from(upgradeBatches)
+    .where(sql`${upgradeBatches.status} IN ('queued', 'running')`)
+    .orderBy(asc(upgradeBatches.createdAt), asc(upgradeBatches.id))
+    .get();
+}
+
+function getSystemUpdateCounts(): Map<number, number> {
+  return new Map(
+    systemService
+      .listVisibleSystemsWithUpdateCounts()
+      .map((system) => [system.id, system.updateCount])
+  );
+}
+
+function validateBatchItems(items: BatchItemInput[]): BatchItemInput[] {
+  if (!Array.isArray(items) || items.length === 0) {
+    throw new Error("At least one system is required");
+  }
+  const seen = new Set<number>();
+  const updateCounts = getSystemUpdateCounts();
+  const normalized: BatchItemInput[] = [];
+  for (const item of items) {
+    if (!Number.isInteger(item.systemId) || item.systemId <= 0) {
+      throw new Error("System IDs must be positive integers");
+    }
+    if (seen.has(item.systemId)) {
+      throw new Error("System list contains duplicate IDs");
+    }
+    if (!updateCounts.has(item.systemId)) {
+      throw new Error("System is not visible");
+    }
+    if ((updateCounts.get(item.systemId) ?? 0) <= 0) {
+      throw new Error("Only systems with updates can be queued");
+    }
+    if (
+      item.defaultUpgradeModeOverride !== undefined &&
+      item.defaultUpgradeModeOverride !== "standard" &&
+      item.defaultUpgradeModeOverride !== "aggressive"
+    ) {
+      throw new Error("defaultUpgradeModeOverride must be 'standard' or 'aggressive'");
+    }
+    seen.add(item.systemId);
+    normalized.push({
+      systemId: item.systemId,
+      defaultUpgradeModeOverride: item.defaultUpgradeModeOverride,
+    });
+  }
+  return normalized;
+}
+
+function insertQueuedHistory(input: {
+  systemId: number;
+  pkgManager: string;
+  command: string | null;
+  packageCount: number;
+}): number {
+  const inserted = getDb()
+    .insert(updateHistory)
+    .values({
+      systemId: input.systemId,
+      action: "upgrade_all",
+      pkgManager: input.pkgManager,
+      packageCount: input.packageCount,
+      command: input.command ? sanitizeCommand(input.command) : null,
+      status: "queued",
+      startedAt: now(),
+      completedAt: null,
+    })
+    .returning({ id: updateHistory.id })
+    .get();
+  updateService.pruneHistoryForSystem(input.systemId);
+  return inserted.id;
+}
+
+export function createUpgradeBatch(items: BatchItemInput[], options?: { autoRun?: boolean }): { batchId: number } {
+  if (getActiveBatch()) {
+    throw new Error("An Upgrade All batch is already queued or running");
+  }
+
+  const normalized = validateBatchItems(items);
+  const db = getDb();
+  const groupRows = db.select().from(upgradeGroups).all();
+  const groupsById = new Map(groupRows.map((group) => [group.id, group]));
+  const ungroupedSortOrder = systemService.getUngroupedUpgradeGroupSortOrder();
+  const systemsById = new Map(
+    db
+      .select()
+      .from(systems)
+      .where(inArray(systems.id, normalized.map((item) => item.systemId)))
+      .all()
+      .map((system) => [system.id, system])
+  );
+  const updateCounts = getSystemUpdateCounts();
+
+  const batch = db
+    .insert(upgradeBatches)
+    .values({ status: "queued" })
+    .returning({ id: upgradeBatches.id })
+    .get();
+
+  for (const item of normalized) {
+    const system = systemsById.get(item.systemId);
+    if (!system) continue;
+    const group = system.upgradeGroupId ? groupsById.get(system.upgradeGroupId) : undefined;
+    const snapshot = updateService.getUpgradeAllCommandSnapshot(item.systemId, {
+      defaultUpgradeModeOverride: item.defaultUpgradeModeOverride,
+    });
+    const historyId = insertQueuedHistory({
+      systemId: item.systemId,
+      pkgManager: snapshot.pkgManager,
+      command: snapshot.command,
+      packageCount: updateCounts.get(item.systemId) ?? 0,
+    });
+    db.insert(upgradeBatchItems)
+      .values({
+        batchId: batch.id,
+        systemId: item.systemId,
+        groupId: system.upgradeGroupId ?? null,
+        groupSortOrder: group?.sortOrder ?? ungroupedSortOrder,
+        systemSortOrder: system.upgradeOrder ?? 1,
+        defaultUpgradeModeOverride: item.defaultUpgradeModeOverride ?? null,
+        status: "queued",
+        command: snapshot.command,
+        pkgManager: snapshot.pkgManager,
+        historyId,
+      })
+      .run();
+  }
+
+  if (options?.autoRun !== false) {
+    void runUpgradeBatches();
+  }
+  return { batchId: batch.id };
+}
+
+let runnerActive = false;
+
+function getNextGroupItems(batchId: number) {
+  const db = getDb();
+  const activeRows = db
+    .select()
+    .from(upgradeBatchItems)
+    .where(
+      and(
+        eq(upgradeBatchItems.batchId, batchId),
+        sql`${upgradeBatchItems.status} IN ('queued', 'running')`,
+      ),
+    )
+    .orderBy(
+      asc(upgradeBatchItems.groupSortOrder),
+      asc(upgradeBatchItems.systemSortOrder),
+      asc(upgradeBatchItems.id),
+    )
+    .all();
+  const first = activeRows[0];
+  if (!first) return [];
+  return activeRows.filter((row) => row.groupSortOrder === first.groupSortOrder);
+}
+
+async function runBatchItem(itemId: number): Promise<ItemStatus> {
+  const db = getDb();
+  const item = db.select().from(upgradeBatchItems).where(eq(upgradeBatchItems.id, itemId)).get();
+  if (!item || isTerminal(item.status)) return (item?.status as ItemStatus) ?? "failed";
+
+  const resume =
+    item.status === "running" &&
+    item.historyId &&
+    item.currentPkgManager &&
+    item.currentCommand &&
+    item.remotePid &&
+    item.remoteLogFile &&
+    item.remoteExitFile
+      ? {
+          historyId: item.historyId,
+          pkgManager: item.currentPkgManager,
+          command: item.currentCommand,
+          preUpgradeUpdateCount: item.preUpgradeUpdateCount ?? 0,
+          persistentInfo: {
+            pid: item.remotePid,
+            logFile: item.remoteLogFile,
+            exitFile: item.remoteExitFile,
+            scriptFile: item.remoteScriptFile ?? undefined,
+          } satisfies PersistentCommandInfo,
+        }
+      : undefined;
+
+  try {
+    const result = await updateService.applyUpgradeAll(item.systemId, {
+      defaultUpgradeModeOverride:
+        item.defaultUpgradeModeOverride === "standard" || item.defaultUpgradeModeOverride === "aggressive"
+          ? item.defaultUpgradeModeOverride
+          : undefined,
+      queuedHistoryId: resume ? undefined : item.historyId ?? undefined,
+      resume,
+      onStepStarted: ({ historyId, pkgManager, command, preUpgradeUpdateCount }) => {
+        db.update(upgradeBatchItems)
+          .set({
+            status: "running",
+            historyId,
+            currentPkgManager: pkgManager,
+            currentCommand: command,
+            preUpgradeUpdateCount,
+            remotePid: null,
+            remoteLogFile: null,
+            remoteExitFile: null,
+            remoteScriptFile: null,
+            startedAt: item.startedAt ?? now(),
+          })
+          .where(eq(upgradeBatchItems.id, itemId))
+          .run();
+      },
+      onPersistentInfo: ({ info }) => {
+        db.update(upgradeBatchItems)
+          .set({
+            remotePid: info.pid,
+            remoteLogFile: info.logFile,
+            remoteExitFile: info.exitFile,
+            remoteScriptFile: info.scriptFile ?? null,
+          })
+          .where(eq(upgradeBatchItems.id, itemId))
+          .run();
+      },
+    });
+
+    const status: ItemStatus = result.cancelled
+      ? "cancelled"
+      : result.warning
+        ? "warning"
+        : result.success
+          ? "success"
+          : "failed";
+    db.update(upgradeBatchItems)
+      .set({
+        status,
+        error: result.success || result.warning ? null : sanitizeOutput(result.output).slice(0, 2000),
+        completedAt: now(),
+      })
+      .where(eq(upgradeBatchItems.id, itemId))
+      .run();
+    return status;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    db.update(upgradeBatchItems)
+      .set({
+        status: "failed",
+        error: sanitizeOutput(message).slice(0, 2000),
+        completedAt: now(),
+      })
+      .where(eq(upgradeBatchItems.id, itemId))
+      .run();
+    return "failed";
+  }
+}
+
+function summarizeBatch(batchId: number): BatchStatus {
+  const rows = getDb()
+    .select({ status: upgradeBatchItems.status })
+    .from(upgradeBatchItems)
+    .where(eq(upgradeBatchItems.batchId, batchId))
+    .all();
+  if (rows.some((row) => row.status === "queued" || row.status === "running")) return "running";
+  if (rows.some((row) => row.status === "failed")) return "failed";
+  if (rows.some((row) => row.status === "warning")) return "warning";
+  if (rows.some((row) => row.status === "cancelled")) return "cancelled";
+  return "success";
+}
+
+export async function runUpgradeBatches(): Promise<void> {
+  if (runnerActive) return;
+  runnerActive = true;
+  try {
+    while (true) {
+      const batch = getActiveBatch();
+      if (!batch) return;
+      if (batch.status === "queued") {
+        getDb().update(upgradeBatches)
+          .set({ status: "running", startedAt: batch.startedAt ?? now() })
+          .where(eq(upgradeBatches.id, batch.id))
+          .run();
+      }
+
+      while (true) {
+        const groupItems = getNextGroupItems(batch.id);
+        if (groupItems.length === 0) break;
+        await Promise.all(groupItems.map((item) => runBatchItem(item.id)));
+      }
+
+      const status = summarizeBatch(batch.id);
+      getDb().update(upgradeBatches)
+        .set({ status, completedAt: now() })
+        .where(eq(upgradeBatches.id, batch.id))
+        .run();
+    }
+  } catch (error) {
+    logger.error("Upgrade batch runner failed", { error: String(error) });
+  } finally {
+    runnerActive = false;
+  }
+}
+
+export function resumeUpgradeBatches(): void {
+  const db = getDb();
+  db.update(upgradeBatches)
+    .set({ status: "running" })
+    .where(eq(upgradeBatches.status, "queued"))
+    .run();
+  void runUpgradeBatches();
+}
+
+export function getQueuedOrRunningOperation(systemId: number): { type: "upgrade_all"; startedAt: string; phase: "queued" } | null {
+  const item = getDb()
+    .select({
+      status: upgradeBatchItems.status,
+      createdAt: upgradeBatchItems.createdAt,
+      startedAt: upgradeBatchItems.startedAt,
+    })
+    .from(upgradeBatchItems)
+    .innerJoin(upgradeBatches, eq(upgradeBatchItems.batchId, upgradeBatches.id))
+    .where(
+      and(
+        eq(upgradeBatchItems.systemId, systemId),
+        sql`${upgradeBatches.status} IN ('queued', 'running')`,
+        sql`${upgradeBatchItems.status} IN ('queued', 'running')`,
+      ),
+    )
+    .orderBy(desc(upgradeBatchItems.id))
+    .get();
+  if (!item) return null;
+  return {
+    type: "upgrade_all",
+    startedAt: item.startedAt ?? item.createdAt,
+    phase: "queued",
+  };
+}

--- a/server/ssh/reboot.ts
+++ b/server/ssh/reboot.ts
@@ -1,5 +1,36 @@
 import { sudo } from "./parsers/types";
 
+export function getProxmoxBackupGuardCommand(): string {
+  return [
+    "# Block rebooting Proxmox VE while backup tasks are running.",
+    "if ! command -v pveversion >/dev/null 2>&1 && ! command -v pvesh >/dev/null 2>&1; then",
+    "  exit 0",
+    "fi",
+    "",
+    "if ! command -v pvesh >/dev/null 2>&1; then",
+    "  echo \"Reboot blocked: Proxmox detected but pvesh is unavailable.\"",
+    "  exit 1",
+    "fi",
+    "",
+    "tasks=$(",
+    `  ${sudo("pvesh get /cluster/tasks --typefilter vzdump --statusfilter running --output-format json")} 2>&1`,
+    ")",
+    "status=$?",
+    "if [ \"$status\" -ne 0 ]; then",
+    "  echo \"Reboot blocked: could not verify Proxmox backup activity.\"",
+    "  printf '%s\\n' \"$tasks\"",
+    "  exit 1",
+    "fi",
+    "",
+    "if printf '%s\\n' \"$tasks\" | grep -q '\"type\"[[:space:]]*:[[:space:]]*\"vzdump\"' && \\",
+    "   printf '%s\\n' \"$tasks\" | grep -q '\"status\"[[:space:]]*:[[:space:]]*\"running\"'; then",
+    "  echo \"Reboot blocked: Proxmox backup task is running.\"",
+    "  printf '%s\\n' \"$tasks\"",
+    "  exit 1",
+    "fi",
+  ].join("\n");
+}
+
 export function getRebootCommand(): string {
   return [
     "# Reboot the remote system using sudo when the current user is not root.",

--- a/tests/client/client.test.ts
+++ b/tests/client/client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { ApiError, pollJob } from "../../client/lib/client";
+import { ApiError, apiFetch, pollJob } from "../../client/lib/client";
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -59,5 +59,22 @@ describe("pollJob", () => {
       pollJob("job-1", 0, 3, { recoverMissingJob }),
     ).rejects.toMatchObject({ status: 401 } satisfies Partial<ApiError>);
     expect(recoverMissingJob).not.toHaveBeenCalled();
+  });
+});
+
+describe("apiFetch", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("surfaces conflict response messages", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () =>
+      jsonResponse({ error: "Reboot blocked: Proxmox backup task is running." }, 409)
+    ));
+
+    await expect(apiFetch("/systems/1/reboot", { method: "POST" })).rejects.toMatchObject({
+      status: 409,
+      message: "Reboot blocked: Proxmox backup task is running.",
+    } satisfies Partial<ApiError>);
   });
 });

--- a/tests/client/dashboard.test.tsx
+++ b/tests/client/dashboard.test.tsx
@@ -78,6 +78,7 @@ vi.mock("../../client/components/Layout", () => ({
 }));
 
 import Dashboard, {
+  applyUpgradeSystemPlacements,
   canToggleUpgradePreset,
   getDashboardUpgradeToast,
   isUpgradePresetSelected,
@@ -213,5 +214,20 @@ describe("Dashboard", () => {
     expect(isUpgradePresetSelected(systemWithoutUpdates, [1])).toBe(true);
     expect(canToggleUpgradePreset(systemWithoutUpdates, false)).toBe(false);
     expect(canToggleUpgradePreset(systemWithoutUpdates, true)).toBe(true);
+  });
+
+  test("applies pending upgrade group placements over stale system rows", () => {
+    const systems = [
+      { id: 1, upgradeGroupId: null, upgradeOrder: 1, name: "Alpha" },
+      { id: 2, upgradeGroupId: 3, upgradeOrder: 1, name: "Bravo" },
+    ];
+    const placements = new Map([
+      [1, { groupId: 3, upgradeOrder: 2 }],
+    ]);
+
+    expect(applyUpgradeSystemPlacements(systems, placements)).toEqual([
+      { id: 1, upgradeGroupId: 3, upgradeOrder: 2, name: "Alpha" },
+      { id: 2, upgradeGroupId: 3, upgradeOrder: 1, name: "Bravo" },
+    ]);
   });
 });

--- a/tests/client/dashboard.test.tsx
+++ b/tests/client/dashboard.test.tsx
@@ -77,7 +77,11 @@ vi.mock("../../client/components/Layout", () => ({
   ),
 }));
 
-import Dashboard, { getDashboardUpgradeToast } from "../../client/pages/Dashboard";
+import Dashboard, {
+  canToggleUpgradePreset,
+  getDashboardUpgradeToast,
+  isUpgradePresetSelected,
+} from "../../client/pages/Dashboard";
 
 describe("Dashboard", () => {
   beforeEach(() => {
@@ -201,5 +205,13 @@ describe("Dashboard", () => {
       message: "Alpha: Upgrade state resynced after backend restart",
       type: "info",
     });
+  });
+
+  test("allows edit mode to toggle Upgrade All presets for systems without updates", () => {
+    const systemWithoutUpdates = { id: 1, updateCount: 0 };
+
+    expect(isUpgradePresetSelected(systemWithoutUpdates, [1])).toBe(true);
+    expect(canToggleUpgradePreset(systemWithoutUpdates, false)).toBe(false);
+    expect(canToggleUpgradePreset(systemWithoutUpdates, true)).toBe(true);
   });
 });

--- a/tests/client/dashboard.test.tsx
+++ b/tests/client/dashboard.test.tsx
@@ -7,6 +7,13 @@ const {
   mockUseDashboardStats,
   mockUseDashboardSystems,
   mockUseRefreshCache,
+  mockUseUpgradeAllBatch,
+  mockUseUpgradeGroups,
+  mockUseCreateUpgradeGroup,
+  mockUseUpdateUpgradeGroup,
+  mockUseDeleteUpgradeGroup,
+  mockUseReorderUpgradeGroups,
+  mockUseUpdateSystemUpgradeGroups,
   mockUseReorderSystemUpgradeOrder,
   mockUseUpdateSystemUpgradeAllExclusion,
   mockUseUpdateSystemUpgradeMode,
@@ -16,6 +23,13 @@ const {
   mockUseDashboardStats: vi.fn(),
   mockUseDashboardSystems: vi.fn(),
   mockUseRefreshCache: vi.fn(),
+  mockUseUpgradeAllBatch: vi.fn(),
+  mockUseUpgradeGroups: vi.fn(),
+  mockUseCreateUpgradeGroup: vi.fn(),
+  mockUseUpdateUpgradeGroup: vi.fn(),
+  mockUseDeleteUpgradeGroup: vi.fn(),
+  mockUseReorderUpgradeGroups: vi.fn(),
+  mockUseUpdateSystemUpgradeGroups: vi.fn(),
   mockUseReorderSystemUpgradeOrder: vi.fn(),
   mockUseUpdateSystemUpgradeAllExclusion: vi.fn(),
   mockUseUpdateSystemUpgradeMode: vi.fn(),
@@ -30,9 +44,16 @@ vi.mock("../../client/lib/dashboard", () => ({
 
 vi.mock("../../client/lib/updates", () => ({
   useRefreshCache: mockUseRefreshCache,
+  useUpgradeAllBatch: mockUseUpgradeAllBatch,
 }));
 
 vi.mock("../../client/lib/systems", () => ({
+  useUpgradeGroups: mockUseUpgradeGroups,
+  useCreateUpgradeGroup: mockUseCreateUpgradeGroup,
+  useUpdateUpgradeGroup: mockUseUpdateUpgradeGroup,
+  useDeleteUpgradeGroup: mockUseDeleteUpgradeGroup,
+  useReorderUpgradeGroups: mockUseReorderUpgradeGroups,
+  useUpdateSystemUpgradeGroups: mockUseUpdateSystemUpgradeGroups,
   useReorderSystemUpgradeOrder: mockUseReorderSystemUpgradeOrder,
   useUpdateSystemUpgradeAllExclusion: mockUseUpdateSystemUpgradeAllExclusion,
   useUpdateSystemUpgradeMode: mockUseUpdateSystemUpgradeMode,
@@ -100,6 +121,13 @@ describe("Dashboard", () => {
       dataUpdatedAt: Date.now(),
     });
     mockUseRefreshCache.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    mockUseUpgradeAllBatch.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    mockUseUpgradeGroups.mockReturnValue({ data: { groups: [], ungroupedSortOrder: 1_000_000 } });
+    mockUseCreateUpgradeGroup.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    mockUseUpdateUpgradeGroup.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    mockUseDeleteUpgradeGroup.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    mockUseReorderUpgradeGroups.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    mockUseUpdateSystemUpgradeGroups.mockReturnValue({ mutate: vi.fn(), isPending: false });
     mockUseReorderSystemUpgradeOrder.mockReturnValue({ mutate: vi.fn(), isPending: false });
     mockUseUpdateSystemUpgradeAllExclusion.mockReturnValue({ mutate: vi.fn(), isPending: false });
     mockUseUpdateSystemUpgradeMode.mockReturnValue({ mutate: vi.fn(), isPending: false, variables: undefined });

--- a/tests/client/scripts-page.test.tsx
+++ b/tests/client/scripts-page.test.tsx
@@ -60,7 +60,23 @@ vi.mock("../../client/components/ConfirmDialog", () => ({
   ConfirmDialog: () => null,
 }));
 
-import Scripts from "../../client/pages/Scripts";
+import Scripts, { ScriptEditor } from "../../client/pages/Scripts";
+import type { ScriptDefinition } from "../../client/lib/scripts";
+
+function renderEditor(script: ScriptDefinition): string {
+  return renderToStaticMarkup(
+    <ScriptEditor
+      script={script}
+      packageManagers={[
+        { name: "apt", label: "APT" },
+        { name: "brewlinux", label: "Linuxbrew" },
+      ]}
+      placeholders={[]}
+      onSave={vi.fn()}
+      onCancel={vi.fn()}
+    />,
+  );
+}
 
 describe("Scripts page", () => {
   beforeEach(() => {
@@ -200,5 +216,134 @@ describe("Scripts page", () => {
     expect(html).toContain("Assigned to web-42");
     expect(html).toContain("web-42");
     expect(html).toContain("Detection");
+  });
+
+  test("explains built-in package-manager check runtime behavior", () => {
+    const html = renderEditor({
+      id: "builtin:apt:check_updates",
+      readonly: true,
+      name: "Check APT updates",
+      description: null,
+      type: "package_manager",
+      operation: "check_updates",
+      pkgManager: "apt",
+      steps: [{ label: "List updates", command: "apt list --upgradable" }],
+      parserConfig: null,
+      systemInfoConfig: null,
+      sourceScriptId: null,
+    });
+
+    expect(html).toContain("Runtime behavior");
+    expect(html).toContain("Steps, output, parser, and exit codes");
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain("parser input");
+  });
+
+  test("keeps detection scripts to one clear step", () => {
+    const html = renderEditor({
+      id: "custom:10",
+      readonly: false,
+      name: "Detect Linuxbrew",
+      description: null,
+      type: "package_manager",
+      operation: "detect",
+      pkgManager: "brewlinux",
+      steps: [{ label: "Detect Linuxbrew", command: "command -v brew && echo found" }],
+      parserConfig: null,
+      systemInfoConfig: null,
+      sourceScriptId: null,
+    });
+
+    expect(html).toContain("Detection scripts use one command");
+    expect(html).toContain("Detection scripts use one step");
+    expect(html).toContain("detection output");
+  });
+
+  test("shows custom parser output selection and step badges", () => {
+    const html = renderEditor({
+      id: "custom:11",
+      readonly: false,
+      name: "Check Linuxbrew",
+      description: null,
+      type: "package_manager",
+      operation: "check_updates",
+      pkgManager: "brewlinux",
+      steps: [
+        { label: "Refresh metadata", command: "brew update" },
+        { label: "List updates", command: "brew outdated" },
+      ],
+      parserConfig: {
+        parseStep: 0,
+        updateRegex: "^(?<packageName>\\S+)\\s+(?<newVersion>\\S+)$",
+      },
+      systemInfoConfig: null,
+      sourceScriptId: null,
+    });
+
+    expect(html).toContain("Output to Parse");
+    expect(html).toContain("Step 1: Refresh metadata");
+    expect(html).toContain("Last step (List updates)");
+    expect(html).toContain("parsed output");
+    expect(html).toContain("streamed only");
+  });
+
+  test("warns when a saved parser output step no longer exists", () => {
+    const html = renderEditor({
+      id: "custom:12",
+      readonly: false,
+      name: "Broken custom check",
+      description: null,
+      type: "package_manager",
+      operation: "check_updates",
+      pkgManager: "brewlinux",
+      steps: [{ label: "List updates", command: "brew outdated" }],
+      parserConfig: {
+        parseStep: 3,
+        updateRegex: "^(?<packageName>\\S+)\\s+(?<newVersion>\\S+)$",
+      },
+      systemInfoConfig: null,
+      sourceScriptId: null,
+    });
+
+    expect(html).toContain("The saved parser step is outside the current step list.");
+    expect(html).toContain("Missing step 4");
+  });
+
+  test("explains system-info and reboot step output behavior", () => {
+    const systemInfoHtml = renderEditor({
+      id: "custom:13",
+      readonly: false,
+      name: "System info",
+      description: null,
+      type: "system",
+      operation: "system_info",
+      pkgManager: null,
+      steps: [{ label: "Collect", command: "echo OS" }],
+      parserConfig: null,
+      systemInfoConfig: { mode: "sectioned" },
+      sourceScriptId: null,
+    });
+    const rebootHtml = renderEditor({
+      id: "custom:14",
+      readonly: false,
+      name: "Reboot",
+      description: null,
+      type: "system",
+      operation: "reboot",
+      pkgManager: null,
+      steps: [
+        { label: "Safety check", command: "true" },
+        { label: "Reboot", command: "reboot" },
+      ],
+      parserConfig: null,
+      systemInfoConfig: null,
+      sourceScriptId: null,
+    });
+
+    expect(systemInfoHtml).toContain("system fields");
+    expect(systemInfoHtml).toContain("Advanced system-info mapping");
+    expect(rebootHtml).toContain("reboot guard");
+    expect(rebootHtml).toContain("reboot command");
+    expect(rebootHtml).toContain("Steps, output, parser, and exit codes");
   });
 });

--- a/tests/server/reboot-system.test.ts
+++ b/tests/server/reboot-system.test.ts
@@ -40,11 +40,16 @@ describe("rebootSystem", () => {
     const sshManager = initSSHManager(1, 1, 1, encryptor);
     (sshManager as any).connect = async () => ({});
     (sshManager as any).disconnect = () => {};
-    (sshManager as any).runCommand = async () => ({
-      stdout: "",
-      stderr: "Failed to talk to init daemon.\n",
-      exitCode: 1,
-    });
+    (sshManager as any).runCommand = async (_conn: unknown, command: string) => {
+      if (command.includes("/cluster/tasks")) {
+        return { stdout: "[]", stderr: "", exitCode: 0 };
+      }
+      return {
+        stdout: "",
+        stderr: "Failed to talk to init daemon.\n",
+        exitCode: 1,
+      };
+    };
 
     const result = await rebootSystem(inserted.id);
     expect(result.success).toBe(false);
@@ -59,11 +64,12 @@ describe("rebootSystem", () => {
       .all()
       .at(-1);
     expect(JSON.parse(history?.steps || "[]")).toMatchObject([
+      { label: "Pre-reboot safety checks", pkgManager: "system", status: "success" },
       {
         pkgManager: "system",
         status: "failed",
         command: expect.stringContaining("reboot"),
-        error: "Failed to talk to init daemon.\n",
+        error: "Reboot failed: Failed to talk to init daemon.\n",
       },
     ]);
   });
@@ -83,11 +89,16 @@ describe("rebootSystem", () => {
     const sshManager = initSSHManager(1, 1, 1, encryptor);
     (sshManager as any).connect = async () => ({});
     (sshManager as any).disconnect = () => {};
-    (sshManager as any).runCommand = async () => ({
-      stdout: "",
-      stderr: "read ECONNRESET",
-      exitCode: -1,
-    });
+    (sshManager as any).runCommand = async (_conn: unknown, command: string) => {
+      if (command.includes("/cluster/tasks")) {
+        return { stdout: "[]", stderr: "", exitCode: 0 };
+      }
+      return {
+        stdout: "",
+        stderr: "read ECONNRESET",
+        exitCode: -1,
+      };
+    };
 
     const result = await rebootSystem(inserted.id);
     expect(result).toEqual({ success: true, message: "Reboot command sent" });
@@ -102,11 +113,67 @@ describe("rebootSystem", () => {
       .at(-1);
     expect(history?.status).toBe("success");
     expect(JSON.parse(history?.steps || "[]")).toMatchObject([
+      { label: "Pre-reboot safety checks", pkgManager: "system", status: "success" },
       {
         pkgManager: "system",
         status: "success",
         command: expect.stringContaining("reboot"),
         error: null,
+      },
+    ]);
+  });
+
+  test("blocks reboot when Proxmox backup activity is detected", async () => {
+    const db = getDb();
+    const encryptor = getEncryptor();
+    const inserted = db.insert(systems).values({
+      name: "Proxmox",
+      hostname: "localhost",
+      port: 2006,
+      authType: "password",
+      username: "testuser",
+      encryptedPassword: encryptor.encrypt("testpass"),
+    }).returning({ id: systems.id }).get();
+
+    const sshManager = initSSHManager(1, 1, 1, encryptor);
+    const commands: string[] = [];
+    (sshManager as any).connect = async () => ({});
+    (sshManager as any).disconnect = () => {};
+    (sshManager as any).runCommand = async (_conn: unknown, command: string) => {
+      commands.push(command);
+      return {
+        stdout: 'Reboot blocked: Proxmox backup task is running.\n[{"type":"vzdump","status":"running"}]\n',
+        stderr: "",
+        exitCode: 1,
+      };
+    };
+
+    const result = await rebootSystem(inserted.id);
+
+    expect(result).toEqual({
+      success: false,
+      message: "Reboot blocked: Proxmox backup task is running.",
+      blocked: true,
+    });
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toContain("/cluster/tasks");
+
+    const system = db.select().from(systems).where(eq(systems.id, inserted.id)).get();
+    expect(system?.isReachable).toBe(0);
+
+    const history = db.select()
+      .from(updateHistory)
+      .where(eq(updateHistory.systemId, inserted.id))
+      .all()
+      .at(-1);
+    expect(history?.status).toBe("failed");
+    expect(history?.error).toBe("Reboot blocked: Proxmox backup task is running.");
+    expect(JSON.parse(history?.steps || "[]")).toMatchObject([
+      {
+        label: "Pre-reboot safety checks",
+        pkgManager: "system",
+        status: "failed",
+        error: "Reboot blocked: Proxmox backup task is running.",
       },
     ]);
   });
@@ -145,5 +212,50 @@ describe("rebootSystem", () => {
 
     expect(result).toEqual({ success: true, message: "Reboot command sent" });
     expect(commands).toEqual(["echo custom-reboot"]);
+  });
+
+  test("stops multi-step reboot scripts before later steps when an earlier step fails", async () => {
+    const db = getDb();
+    const encryptor = getEncryptor();
+    const inserted = db.insert(systems).values({
+      name: "Debian",
+      hostname: "localhost",
+      port: 2007,
+      authType: "password",
+      username: "testuser",
+      encryptedPassword: encryptor.encrypt("testpass"),
+    }).returning({ id: systems.id }).get();
+    const script = createScript({
+      name: "Guarded reboot",
+      type: "system",
+      operation: "reboot",
+      steps: [
+        { label: "Local preflight", command: "echo custom-preflight" },
+        { label: "Custom reboot", command: "echo custom-reboot" },
+      ],
+    });
+    setSystemOverrides(inserted.id, {
+      [buildOperationKey("reboot")]: script.id,
+    });
+
+    const sshManager = initSSHManager(1, 1, 1, encryptor);
+    const commands: string[] = [];
+    (sshManager as any).connect = async () => ({});
+    (sshManager as any).disconnect = () => {};
+    (sshManager as any).runCommand = async (_conn: unknown, command: string) => {
+      commands.push(command);
+      if (command.includes("/cluster/tasks")) {
+        return { stdout: "[]", stderr: "", exitCode: 0 };
+      }
+      if (command === "echo custom-preflight") {
+        return { stdout: "", stderr: "preflight failed", exitCode: 2 };
+      }
+      return { stdout: "should not run", stderr: "", exitCode: 0 };
+    };
+
+    const result = await rebootSystem(inserted.id);
+
+    expect(result).toEqual({ success: false, message: "Reboot failed: preflight failed", blocked: false });
+    expect(commands).toEqual(["echo custom-preflight"]);
   });
 });

--- a/tests/server/script-service.test.ts
+++ b/tests/server/script-service.test.ts
@@ -168,6 +168,17 @@ describe("script service", () => {
     })).toThrow(/at most 8/);
 
     expect(() => createScript({
+      name: "Ambiguous detection",
+      type: "package_manager",
+      operation: "detect",
+      pkgManager: "apt",
+      steps: [
+        { label: "Detect apt", command: "command -v apt" },
+        { label: "Detect apt-get", command: "command -v apt-get" },
+      ],
+    })).toThrow(/exactly one step/);
+
+    expect(() => createScript({
       name: "Bad step",
       type: "package_manager",
       operation: "detect",
@@ -206,6 +217,35 @@ describe("script service", () => {
         updateRegex: "^(?<packageName>\\S+)\\s+->\\s+(?<newVersion>\\S+)$",
       },
     })).not.toThrow();
+  });
+
+  test("validates parser output step against check script steps", () => {
+    expect(() => createScript({
+      name: "Two-step check",
+      type: "package_manager",
+      operation: "check_updates",
+      pkgManager: "apt",
+      steps: [
+        { label: "Refresh", command: "apt-get update" },
+        { label: "List", command: "apt list --upgradable" },
+      ],
+      parserConfig: {
+        parseStep: 1,
+        updateRegex: "^(?<packageName>\\S+)\\s+(?<newVersion>\\S+)$",
+      },
+    })).not.toThrow();
+
+    expect(() => createScript({
+      name: "Missing parser step",
+      type: "package_manager",
+      operation: "check_updates",
+      pkgManager: "apt",
+      steps: [{ label: "List", command: "apt list --upgradable" }],
+      parserConfig: {
+        parseStep: 1,
+        updateRegex: "^(?<packageName>\\S+)\\s+(?<newVersion>\\S+)$",
+      },
+    })).toThrow(/reference an existing step/);
   });
 
   test("rejects oversized and invalid formatter input", async () => {

--- a/tests/server/script-service.test.ts
+++ b/tests/server/script-service.test.ts
@@ -129,6 +129,50 @@ describe("script service", () => {
     expect(() => deleteScript(copy.id)).toThrow(/assigned/);
   });
 
+  test("does not allow assigned scripts to change operation scope", () => {
+    const script = createBuiltinCopy("builtin:apt:check_updates");
+    insertSystem(20);
+    setSystemOverrides(20, {
+      [buildOperationKey("check_updates", "apt")]: script.id,
+    });
+
+    expect(() => updateScript(script.id, {
+      operation: "upgrade_all",
+      steps: [{ label: "Upgrade", command: "echo changed" }],
+    })).toThrow(/cannot be changed while assigned/);
+
+    expect(resolveRuntimeSteps({
+      systemId: 20,
+      operation: "check_updates",
+      pkgManager: "apt",
+    })[0]?.command).not.toBe("echo changed");
+  });
+
+  test("ignores stale incompatible overrides at runtime", () => {
+    const script = createScript({
+      name: "APT upgrade script",
+      type: "package_manager",
+      operation: "upgrade_all",
+      pkgManager: "apt",
+      steps: [{ label: "Upgrade", command: "echo should-not-run" }],
+    });
+    insertSystem(21);
+    getDb().insert(systemScriptOverrides).values({
+      systemId: 21,
+      operationKey: buildOperationKey("check_updates", "apt"),
+      scriptId: script.id,
+    }).run();
+
+    const steps = resolveRuntimeSteps({
+      systemId: 21,
+      operation: "check_updates",
+      pkgManager: "apt",
+    });
+
+    expect(steps.length).toBeGreaterThan(0);
+    expect(steps.map((step) => step.command)).not.toContain("echo should-not-run");
+  });
+
   test("rejects updates and deletes for built-in scripts", () => {
     expect(() => updateScript("builtin:apt:detect", {
       name: "Edited built-in",

--- a/tests/server/script-service.test.ts
+++ b/tests/server/script-service.test.ts
@@ -448,10 +448,16 @@ describe("script service", () => {
     const reboot = getBuiltinScripts().find((script) => script.id === "builtin:system:reboot");
 
     const formattedApt = await formatShellCommand(aptUpgrade?.steps[0]?.command ?? "");
-    const formattedReboot = await formatShellCommand(reboot?.steps[0]?.command ?? "");
+    const formattedRebootGuard = await formatShellCommand(reboot?.steps[0]?.command ?? "");
+    const formattedReboot = await formatShellCommand(reboot?.steps[1]?.command ?? "");
 
     expect(formattedApt).toContain('if [ "$upgrade_mode" != "full-upgrade" ]; then\n  upgrade_mode="upgrade"\nfi');
     expect(formattedApt).toContain('elif command -v sudo > /dev/null 2>&1; then\n  sudo -S -p');
+    expect(reboot?.steps.map((step) => step.label)).toEqual([
+      "Pre-reboot safety checks",
+      "Reboot system",
+    ]);
+    expect(formattedRebootGuard).toContain("pvesh get /cluster/tasks");
     expect(formattedReboot).toContain('if [ "$(id -u)" = "0" ]; then\n  reboot\nelif command -v sudo > /dev/null 2>&1; then');
   });
 

--- a/tests/server/scripts-routes.test.ts
+++ b/tests/server/scripts-routes.test.ts
@@ -51,6 +51,10 @@ describe("scripts routes security", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.scripts.some((script: { id: string }) => script.id === "builtin:apt:check_updates")).toBe(true);
+    expect(body.operationProfiles).toContainEqual(expect.objectContaining({
+      operation: "check_updates",
+      outputConsumer: expect.stringContaining("custom parsers read one selected step"),
+    }));
   });
 
   test("full app stack blocks unauthenticated script access", async () => {

--- a/tests/server/systems-routes.test.ts
+++ b/tests/server/systems-routes.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { randomBytes } from "crypto";
 import { closeDatabase, getDb, initDatabase } from "../../server/db";
-import { apiTokens, credentials, hiddenUpdates, settings, systems, updateCache, updateHistory, users } from "../../server/db/schema";
+import { apiTokens, credentials, hiddenUpdates, settings, systems, updateCache, updateHistory, upgradeGroups, users } from "../../server/db/schema";
 import systemsRoutes from "../../server/routes/systems";
 import { authMiddleware } from "../../server/middleware/auth";
 import { hashToken } from "../../server/auth/api-token";
@@ -174,6 +174,97 @@ describe("systems reorder route", () => {
       Charlie: 1,
       Alpha: 2,
       Bravo: 3,
+    });
+  });
+
+  test("creates, renames, reorders, and deletes upgrade groups", async () => {
+    const app = new Hono();
+    app.route("/api/systems", systemsRoutes);
+
+    const createAlpha = await app.request("/api/systems/upgrade-groups", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Alpha group" }),
+    });
+    const createBeta = await app.request("/api/systems/upgrade-groups", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Beta group" }),
+    });
+
+    expect(createAlpha.status).toBe(201);
+    expect(createBeta.status).toBe(201);
+    const alpha = await createAlpha.json() as { id: number };
+    const beta = await createBeta.json() as { id: number };
+
+    const rename = await app.request(`/api/systems/upgrade-groups/${alpha.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Core" }),
+    });
+    const reorder = await app.request("/api/systems/upgrade-groups/reorder", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ groupKeys: [beta.id, "ungrouped", alpha.id] }),
+    });
+
+    expect(rename.status).toBe(200);
+    expect(reorder.status).toBe(200);
+    expect(getDb().select().from(upgradeGroups).orderBy(upgradeGroups.sortOrder).all().map((group) => group.name)).toEqual([
+      "Beta group",
+      "Core",
+    ]);
+    const list = await app.request("/api/systems/upgrade-groups");
+    const listBody = await list.json() as { ungroupedSortOrder: number };
+    expect(listBody.ungroupedSortOrder).toBe(1);
+
+    const remove = await app.request(`/api/systems/upgrade-groups/${beta.id}`, { method: "DELETE" });
+    expect(remove.status).toBe(200);
+    expect(getDb().select().from(upgradeGroups).all().map((group) => group.name)).toEqual(["Core"]);
+  });
+
+  test("moves systems between upgrade groups and ungrouped", async () => {
+    const db = getDb();
+    const group = db.insert(upgradeGroups).values({ name: "Wave 1", sortOrder: 0 }).returning({ id: upgradeGroups.id }).get();
+    const inserted = db.insert(systems).values([
+      {
+        name: "Alpha",
+        hostname: "alpha.local",
+        port: 22,
+        authType: "password",
+        username: "root",
+      },
+      {
+        name: "Bravo",
+        hostname: "bravo.local",
+        port: 22,
+        authType: "password",
+        username: "root",
+      },
+    ]).returning({ id: systems.id }).all();
+
+    const app = new Hono();
+    app.route("/api/systems", systemsRoutes);
+
+    const res = await app.request("/api/systems/upgrade-groups/systems", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        items: [
+          { systemId: inserted[0].id, groupId: group.id, upgradeOrder: 2 },
+          { systemId: inserted[1].id, groupId: null, upgradeOrder: 1 },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const rows = db
+      .select({ name: systems.name, upgradeGroupId: systems.upgradeGroupId, upgradeOrder: systems.upgradeOrder })
+      .from(systems)
+      .all();
+    expect(Object.fromEntries(rows.map((row) => [row.name, { groupId: row.upgradeGroupId, order: row.upgradeOrder }]))).toEqual({
+      Alpha: { groupId: group.id, order: 2 },
+      Bravo: { groupId: null, order: 1 },
     });
   });
 

--- a/tests/server/systems-routes.test.ts
+++ b/tests/server/systems-routes.test.ts
@@ -196,6 +196,10 @@ describe("systems reorder route", () => {
     expect(createBeta.status).toBe(201);
     const alpha = await createAlpha.json() as { id: number };
     const beta = await createBeta.json() as { id: number };
+    expect(getDb().select().from(upgradeGroups).orderBy(upgradeGroups.sortOrder).all().map((group) => group.name)).toEqual([
+      "Beta group",
+      "Alpha group",
+    ]);
 
     const rename = await app.request(`/api/systems/upgrade-groups/${alpha.id}`, {
       method: "PUT",

--- a/tests/server/systems-routes.test.ts
+++ b/tests/server/systems-routes.test.ts
@@ -1137,6 +1137,58 @@ describe("systems reorder route", () => {
     }
   });
 
+  test("bearer tokens cannot mutate script-affecting package manager fields", async () => {
+    const token = await createBearerToken();
+    const protectedApp = new Hono();
+    protectedApp.use("/api/*", authMiddleware);
+    protectedApp.route("/api/systems", systemsRoutes);
+    const headers = {
+      "Authorization": `Bearer ${token}`,
+      "Content-Type": "application/json",
+    };
+    const incoming = {
+      socket: {
+        remoteAddress: "127.0.0.1",
+        remotePort: 12345,
+        remoteFamily: "IPv4",
+      },
+    };
+
+    const cases = [
+      {
+        path: "/api/systems",
+        body: { detectedPkgManagers: ["custom-apt"] },
+        error: "API tokens cannot modify detected package managers",
+      },
+      {
+        path: "/api/systems",
+        body: { pkgManagerConfigs: { "custom-apt": { channel: "edge" } } },
+        error: "API tokens cannot modify package manager configs",
+      },
+      {
+        path: "/api/systems/1",
+        body: { detectedPkgManagers: ["custom-apt"] },
+        error: "API tokens cannot modify detected package managers",
+      },
+      {
+        path: "/api/systems/1",
+        body: { pkgManagerConfigs: { "custom-apt": { channel: "edge" } } },
+        error: "API tokens cannot modify package manager configs",
+      },
+    ];
+
+    for (const entry of cases) {
+      const res = await protectedApp.request(entry.path, {
+        method: entry.path.endsWith("/systems") ? "POST" : "PUT",
+        headers,
+        body: JSON.stringify(entry.body),
+      }, { incoming });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({ error: entry.error });
+    }
+  });
+
   test("filters hidden systems when requesting visible scope", async () => {
     const db = getDb();
     db.insert(systems).values([

--- a/tests/server/upgrade-batch-service.test.ts
+++ b/tests/server/upgrade-batch-service.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { eq } from "drizzle-orm";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { closeDatabase, getDb, initDatabase } from "../../server/db";
+import { systems, updateCache, updateHistory, upgradeBatchItems, upgradeBatches, upgradeGroups } from "../../server/db/schema";
+import { createUpgradeBatch } from "../../server/services/upgrade-batch-service";
+
+describe("upgrade batch service", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "ludash-upgrade-batch-test-"));
+    initDatabase(join(tempDir, "dashboard.db"));
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("persists queued items and queued activity rows", () => {
+    const db = getDb();
+    const group = db.insert(upgradeGroups).values({ name: "Wave 1", sortOrder: 0 }).returning({ id: upgradeGroups.id }).get();
+    const inserted = db.insert(systems).values([
+      {
+        name: "Alpha",
+        hostname: "alpha.local",
+        port: 22,
+        authType: "password",
+        username: "root",
+        pkgManager: "apt",
+        detectedPkgManagers: JSON.stringify(["apt"]),
+        upgradeGroupId: group.id,
+        upgradeOrder: 2,
+      },
+      {
+        name: "Bravo",
+        hostname: "bravo.local",
+        port: 22,
+        authType: "password",
+        username: "root",
+        pkgManager: "apt",
+        detectedPkgManagers: JSON.stringify(["apt"]),
+        upgradeOrder: 1,
+      },
+    ]).returning({ id: systems.id }).all();
+    db.insert(updateCache).values([
+      {
+        systemId: inserted[0].id,
+        pkgManager: "apt",
+        packageName: "openssl",
+        newVersion: "1.2.3",
+      },
+      {
+        systemId: inserted[1].id,
+        pkgManager: "apt",
+        packageName: "bash",
+        newVersion: "5.3",
+      },
+    ]).run();
+
+    const { batchId } = createUpgradeBatch(
+      [
+        { systemId: inserted[0].id, defaultUpgradeModeOverride: "aggressive" },
+        { systemId: inserted[1].id },
+      ],
+      { autoRun: false },
+    );
+
+    expect(db.select().from(upgradeBatches).where(eq(upgradeBatches.id, batchId)).get()?.status).toBe("queued");
+    const items = db
+      .select()
+      .from(upgradeBatchItems)
+      .where(eq(upgradeBatchItems.batchId, batchId))
+      .all();
+    expect(items.map((item) => item.status)).toEqual(["queued", "queued"]);
+    expect(items.find((item) => item.systemId === inserted[0].id)?.groupId).toBe(group.id);
+    expect(items.find((item) => item.systemId === inserted[0].id)?.groupSortOrder).toBe(0);
+    expect(items.find((item) => item.systemId === inserted[1].id)?.groupSortOrder).toBe(1_000_000);
+
+    const history = db.select().from(updateHistory).all();
+    expect(history).toHaveLength(2);
+    expect(history.every((row) => row.status === "queued")).toBe(true);
+    expect(history.every((row) => row.action === "upgrade_all")).toBe(true);
+    expect(history.every((row) => row.command?.includes("apt"))).toBe(true);
+  });
+});


### PR DESCRIPTION
- Add pre-reboot safety checks
- Clarify script runtime behavior
- Add persisted grouped upgrade all queue
- docs: update README
- fix: harden custom script execution controls
- Allow preset toggles for systems without updates
- Improve upgrade all modal row states
- Restrict upgrade dialog reordering to edit mode
- Fix Upgrade All modal drag ordering