### PR TITLE
Improve terminal output rendering and activity history

### DIFF
--- a/client/components/CopyableCodeBlock.tsx
+++ b/client/components/CopyableCodeBlock.tsx
@@ -1,0 +1,128 @@
+import {
+  forwardRef,
+  useEffect,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+  type UIEventHandler,
+} from "react";
+import { useOptionalToast } from "../context/ToastContext";
+
+async function writeClipboard(text: string) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "true");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  try {
+    if (!document.execCommand("copy")) {
+      throw new Error("Copy command failed");
+    }
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+function CopyIcon({ copied }: { copied: boolean }) {
+  if (copied) {
+    return (
+      <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+    </svg>
+  );
+}
+
+export function CopyButton({
+  text,
+  className = "",
+  disabled = false,
+  successMessage = "Copied to clipboard",
+}: {
+  text: string;
+  className?: string;
+  disabled?: boolean;
+  successMessage?: string;
+}) {
+  const toast = useOptionalToast();
+  const [copied, setCopied] = useState(false);
+  const canCopy = !disabled && text.length > 0;
+
+  useEffect(() => {
+    if (!copied) return;
+    const timeout = window.setTimeout(() => setCopied(false), 1500);
+    return () => window.clearTimeout(timeout);
+  }, [copied]);
+
+  const copy = async () => {
+    if (!canCopy) return;
+
+    try {
+      await writeClipboard(text);
+      setCopied(true);
+      toast?.addToast(successMessage, "success");
+    } catch {
+      toast?.addToast("Could not copy to clipboard", "danger");
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      disabled={!canCopy}
+      className={`inline-flex h-7 w-7 items-center justify-center rounded-md border border-slate-600/70 bg-slate-800/90 text-slate-200 shadow-sm transition-colors hover:bg-slate-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40 ${className}`}
+      title={copied ? "Copied" : "Copy to clipboard"}
+      aria-label={copied ? "Copied" : "Copy to clipboard"}
+    >
+      <CopyIcon copied={copied} />
+    </button>
+  );
+}
+
+export const CopyableCodeBlock = forwardRef<
+  HTMLPreElement,
+  {
+    text: string;
+    children: ReactNode;
+    className: string;
+    style?: CSSProperties;
+    onScroll?: UIEventHandler<HTMLPreElement>;
+    successMessage?: string;
+  }
+>(function CopyableCodeBlock(
+  { text, children, className, style, onScroll, successMessage },
+  ref,
+) {
+  return (
+    <div className="relative">
+      <CopyButton
+        text={text}
+        successMessage={successMessage}
+        className="absolute right-2 top-2 z-10"
+      />
+      <pre
+        ref={ref}
+        onScroll={onScroll}
+        className={className}
+        style={{ ...style, paddingRight: "3.25rem" }}
+      >
+        {children}
+      </pre>
+    </div>
+  );
+});

--- a/client/components/TerminalOutput.tsx
+++ b/client/components/TerminalOutput.tsx
@@ -1,6 +1,7 @@
 import { useRef, useEffect, useMemo } from "react";
 import type { WsMessage } from "../hooks/useCommandOutput";
 import { CopyButton } from "./CopyableCodeBlock";
+import { TerminalText } from "./TerminalText";
 
 interface TerminalOutputProps {
   messages: WsMessage[];
@@ -113,11 +114,8 @@ export function TerminalOutput({ messages, isActive, phase, connected }: Termina
               );
             case "output":
               return (
-                <span
-                  key={i}
-                  className={msg.stream === "stderr" ? "text-red-400" : undefined}
-                >
-                  {msg.data}
+                <span key={i}>
+                  <TerminalText text={msg.data} stream={msg.stream} />
                 </span>
               );
             case "phase":

--- a/client/components/TerminalOutput.tsx
+++ b/client/components/TerminalOutput.tsx
@@ -1,5 +1,6 @@
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useMemo } from "react";
 import type { WsMessage } from "../hooks/useCommandOutput";
+import { CopyButton } from "./CopyableCodeBlock";
 
 interface TerminalOutputProps {
   messages: WsMessage[];
@@ -11,6 +12,26 @@ interface TerminalOutputProps {
 export function TerminalOutput({ messages, isActive, phase, connected }: TerminalOutputProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const isScrolledToBottom = useRef(true);
+  const copyText = useMemo(() => {
+    return messages.map((msg) => {
+      switch (msg.type) {
+        case "started":
+          return `$ ${msg.command}\n`;
+        case "output":
+          return msg.data;
+        case "phase":
+          return `--- ${msg.phase === "rechecking" ? "Rechecking for updates..." : msg.phase} ---\n`;
+        case "done":
+          return `${msg.success ? "Done." : "Failed."}\n`;
+        case "error":
+          return `Error: ${msg.message}\n`;
+        case "warning":
+          return `Warning: ${msg.message}\n`;
+        default:
+          return "";
+      }
+    }).join("");
+  }, [messages]);
 
   const handleScroll = () => {
     const el = containerRef.current;
@@ -63,6 +84,11 @@ export function TerminalOutput({ messages, isActive, phase, connected }: Termina
           {!connected && (
             <span className="text-xs text-amber-400">Disconnected</span>
           )}
+          <CopyButton
+            text={copyText}
+            className="h-6 w-6"
+            successMessage="Copied command output"
+          />
         </div>
       </div>
 

--- a/client/components/TerminalText.tsx
+++ b/client/components/TerminalText.tsx
@@ -1,0 +1,140 @@
+type TerminalStream = "stdout" | "stderr";
+
+interface AnsiState {
+  classes: string[];
+  hasColor: boolean;
+}
+
+interface TerminalChunk {
+  text: string;
+  classes: string[];
+  hasColor: boolean;
+}
+
+const ANSI_PATTERN = /\x1b\[([0-9;]*)?([A-Za-z])/g;
+
+const ANSI_COLOR_CLASSES: Record<number, string> = {
+  30: "text-slate-700",
+  31: "text-red-400",
+  32: "text-green-400",
+  33: "text-amber-300",
+  34: "text-blue-400",
+  35: "text-fuchsia-400",
+  36: "text-cyan-300",
+  37: "text-slate-200",
+  90: "text-slate-500",
+  91: "text-red-300",
+  92: "text-green-300",
+  93: "text-yellow-200",
+  94: "text-blue-300",
+  95: "text-fuchsia-300",
+  96: "text-cyan-200",
+  97: "text-white",
+};
+
+const STYLE_CLASSES: Record<number, string> = {
+  1: "font-semibold",
+  2: "opacity-70",
+  3: "italic",
+  4: "underline underline-offset-2",
+};
+
+function removeMatchingClass(classes: string[], predicate: (className: string) => boolean): string[] {
+  return classes.filter((className) => !predicate(className));
+}
+
+function addClass(classes: string[], className: string): string[] {
+  return classes.includes(className) ? classes : [...classes, className];
+}
+
+function applyAnsiCodes(state: AnsiState, codes: number[]): AnsiState {
+  let classes = [...state.classes];
+  let hasColor = state.hasColor;
+
+  for (const code of codes.length ? codes : [0]) {
+    if (code === 0) {
+      classes = [];
+      hasColor = false;
+    } else if (code === 22) {
+      classes = removeMatchingClass(classes, (className) => className === "font-semibold" || className === "opacity-70");
+    } else if (code === 23) {
+      classes = removeMatchingClass(classes, (className) => className === "italic");
+    } else if (code === 24) {
+      classes = removeMatchingClass(classes, (className) => className.startsWith("underline"));
+    } else if (code === 39) {
+      classes = removeMatchingClass(classes, (className) => className.startsWith("text-"));
+      hasColor = false;
+    } else if (STYLE_CLASSES[code]) {
+      classes = addClass(classes, STYLE_CLASSES[code]);
+    } else if (ANSI_COLOR_CLASSES[code]) {
+      classes = removeMatchingClass(classes, (className) => className.startsWith("text-"));
+      classes = addClass(classes, ANSI_COLOR_CLASSES[code]);
+      hasColor = true;
+    }
+  }
+
+  return { classes, hasColor };
+}
+
+export function parseTerminalText(text: string): TerminalChunk[] {
+  const chunks: TerminalChunk[] = [];
+  const state: AnsiState = { classes: [], hasColor: false };
+  let current = state;
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(ANSI_PATTERN)) {
+    const index = match.index ?? 0;
+    if (index > lastIndex) {
+      chunks.push({
+        text: text.slice(lastIndex, index),
+        classes: current.classes,
+        hasColor: current.hasColor,
+      });
+    }
+
+    if (match[2] === "m") {
+      const codes = (match[1] || "")
+        .split(";")
+        .filter(Boolean)
+        .map((part) => Number.parseInt(part, 10))
+        .filter((code) => Number.isInteger(code));
+      current = applyAnsiCodes(current, codes);
+    }
+
+    lastIndex = index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    chunks.push({
+      text: text.slice(lastIndex),
+      classes: current.classes,
+      hasColor: current.hasColor,
+    });
+  }
+
+  return chunks;
+}
+
+export function TerminalText({
+  text,
+  stream = "stdout",
+}: {
+  text: string;
+  stream?: TerminalStream;
+}) {
+  const fallbackClass = stream === "stderr" ? "text-red-400" : "";
+  const chunks = parseTerminalText(text);
+
+  return (
+    <>
+      {chunks.map((chunk, index) => {
+        const classes = chunk.classes.length ? chunk.classes : fallbackClass ? [fallbackClass] : [];
+        return (
+          <span key={index} className={classes.join(" ") || undefined}>
+            {chunk.text}
+          </span>
+        );
+      })}
+    </>
+  );
+}

--- a/client/context/ToastContext.tsx
+++ b/client/context/ToastContext.tsx
@@ -70,3 +70,7 @@ export function useToast() {
   if (!ctx) throw new Error("useToast must be used within ToastProvider");
   return ctx;
 }
+
+export function useOptionalToast() {
+  return useContext(ToastContext);
+}

--- a/client/lib/shell-highlight.ts
+++ b/client/lib/shell-highlight.ts
@@ -1,0 +1,28 @@
+import hljs from "highlight.js/lib/core";
+import bashLanguage from "highlight.js/lib/languages/bash";
+
+if (!hljs.getLanguage("bash")) {
+  hljs.registerLanguage("bash", bashLanguage);
+}
+
+hljs.configure({ ignoreUnescapedHTML: true });
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export function highlightShell(value: string): string {
+  try {
+    return hljs.highlight(value || "\n", {
+      language: "bash",
+      ignoreIllegals: true,
+    }).value;
+  } catch {
+    return escapeHtml(value);
+  }
+}

--- a/client/pages/Scripts.tsx
+++ b/client/pages/Scripts.tsx
@@ -1,6 +1,4 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import hljs from "highlight.js/lib/core";
-import bashLanguage from "highlight.js/lib/languages/bash";
 import Sortable from "sortablejs";
 import { Layout } from "../components/Layout";
 import { Badge } from "../components/Badge";
@@ -8,6 +6,7 @@ import { Modal } from "../components/Modal";
 import { ConfirmDialog } from "../components/ConfirmDialog";
 import { CopyableCodeBlock, CopyButton } from "../components/CopyableCodeBlock";
 import { useToast } from "../context/ToastContext";
+import { highlightShell } from "../lib/shell-highlight";
 import {
   useCreatePackageManager,
   useCreateScript,
@@ -29,9 +28,6 @@ import {
   type ScriptUsage,
 } from "../lib/scripts";
 import type { CustomPackageManagerConfigEntry } from "../lib/package-manager-configs";
-
-hljs.registerLanguage("bash", bashLanguage);
-hljs.configure({ ignoreUnescapedHTML: true });
 
 const OPERATION_LABELS: Record<ScriptOperation, string> = {
   detect: "Detection",
@@ -413,26 +409,6 @@ function parseExitCodes(value: string): number[] | undefined {
     throw new Error("Exit codes must be comma-separated non-negative integers");
   }
   return codes;
-}
-
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
-
-function highlightShell(value: string): string {
-  try {
-    return hljs.highlight(value || "\n", {
-      language: "bash",
-      ignoreIllegals: true,
-    }).value;
-  } catch {
-    return escapeHtml(value);
-  }
 }
 
 async function formatShellScript(command: string): Promise<string> {

--- a/client/pages/Scripts.tsx
+++ b/client/pages/Scripts.tsx
@@ -6,6 +6,7 @@ import { Layout } from "../components/Layout";
 import { Badge } from "../components/Badge";
 import { Modal } from "../components/Modal";
 import { ConfirmDialog } from "../components/ConfirmDialog";
+import { CopyableCodeBlock, CopyButton } from "../components/CopyableCodeBlock";
 import { useToast } from "../context/ToastContext";
 import {
   useCreatePackageManager,
@@ -467,9 +468,13 @@ function ShellCodeBlock({
 
   const highlighted = useMemo(() => highlightShell(displayCode), [displayCode]);
   return (
-    <pre className={`script-code overflow-x-auto rounded-lg bg-slate-950 px-3 py-2 text-xs leading-5 whitespace-pre-wrap break-words ${className}`}>
+    <CopyableCodeBlock
+      text={displayCode}
+      className={`script-code overflow-x-auto rounded-lg bg-slate-950 px-3 py-2 text-xs leading-5 whitespace-pre-wrap break-words ${className}`}
+      successMessage="Copied script command"
+    >
       <code dangerouslySetInnerHTML={{ __html: highlighted }} />
-    </pre>
+    </CopyableCodeBlock>
   );
 }
 
@@ -493,20 +498,27 @@ function ShellCommandEditor({
     <div>
       <div className="mb-1 flex items-center justify-between gap-3">
         <label htmlFor={id} className={`${labelClass} mb-0`}>Command</label>
-        <button
-          type="button"
-          onClick={onBeautify}
-          disabled={beautifying || !value.trim()}
-          className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5 text-xs text-slate-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-slate-200 dark:hover:bg-slate-700"
-          title="Beautify command"
-        >
-          {beautifying ? <span className="spinner spinner-sm" /> : (
-            <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 20l8.5-8.5m0 0L14 7l3 3-4.5 1.5zm3-14h.01M18 4h.01M20 10h.01M14 20h.01" />
-            </svg>
-          )}
-          Beautify
-        </button>
+        <div className="flex items-center gap-2">
+          <CopyButton
+            text={value}
+            successMessage="Copied command"
+            className="border-border bg-white text-slate-700 hover:bg-slate-50 hover:text-slate-900 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-700"
+          />
+          <button
+            type="button"
+            onClick={onBeautify}
+            disabled={beautifying || !value.trim()}
+            className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5 text-xs text-slate-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-slate-200 dark:hover:bg-slate-700"
+            title="Beautify command"
+          >
+            {beautifying ? <span className="spinner spinner-sm" /> : (
+              <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 20l8.5-8.5m0 0L14 7l3 3-4.5 1.5zm3-14h.01M18 4h.01M20 10h.01M14 20h.01" />
+              </svg>
+            )}
+            Beautify
+          </button>
+        </div>
       </div>
       <div className="relative min-h-36 overflow-hidden rounded-lg border border-border bg-slate-950 focus-within:ring-2 focus-within:ring-blue-500">
         <pre

--- a/client/pages/SystemDetail.tsx
+++ b/client/pages/SystemDetail.tsx
@@ -25,9 +25,10 @@ import type {
   HistoryEntry,
   ActiveOperation,
   ActivityStep,
+  LastCheckSummary,
   PackageManagerIssue,
 } from "../lib/systems";
-import { deriveSystemUpdateState, getUpdatesPanelState, isPostUpgradeRecheck, shouldClearLocalUpgrade } from "../lib/system-status";
+import { deriveSystemUpdateState, getUpdatesPanelState, isPostUpgradeRecheck, shouldClearLocalUpgrade, type UpdatesPanelState } from "../lib/system-status";
 import { getUpgradeBehaviorNotes } from "../lib/package-manager-configs";
 import { getHostKeyStatusText } from "../lib/host-key-status";
 import { formatDurationBetween } from "../lib/time";
@@ -221,11 +222,53 @@ function HiddenUpdatesSection({
   );
 }
 
+function isPackageIssueWarningBlock(
+  block: string,
+  packageIssues: PackageManagerIssue[],
+): boolean {
+  const normalizedBlock = block.trim().toLowerCase();
+  if (!normalizedBlock) return true;
+  return packageIssues.some((issue) => {
+    if (issue.active !== 1) return false;
+    const message = issue.message.trim().toLowerCase();
+    if (!message) return false;
+    return normalizedBlock === `[${issue.pkgManager}] ${message}` || normalizedBlock.includes(message);
+  });
+}
+
+export function dedupePackageIssueUpdateNotice(
+  state: UpdatesPanelState,
+  packageIssues: PackageManagerIssue[],
+): UpdatesPanelState | null {
+  if (state.kind !== "check_warning" || !state.error || packageIssues.length === 0) return state;
+
+  const remainingErrors = state.error
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter((block) => !isPackageIssueWarningBlock(block, packageIssues));
+
+  if (remainingErrors.length === 0) return null;
+  return { ...state, error: remainingErrors.join("\n\n") };
+}
+
+function isSudoCredentialFailure(lastCheck: LastCheckSummary | null): boolean {
+  if (lastCheck?.status !== "failed" || !lastCheck.error) return false;
+  return /sudo:.*(?:password is required|authentication failure|incorrect password)|sudo password/i.test(lastCheck.error);
+}
+
+export function getVisiblePackageIssuesForCurrentCheck(
+  packageIssues: PackageManagerIssue[],
+  lastCheck: LastCheckSummary | null,
+): PackageManagerIssue[] {
+  return isSudoCredentialFailure(lastCheck) ? [] : packageIssues;
+}
+
 function UpdateCheckNotice({
   state,
 }: {
-  state: ReturnType<typeof getUpdatesPanelState>;
+  state: UpdatesPanelState | null;
 }) {
+  if (!state) return null;
   if (state.kind !== "check_failed" && state.kind !== "check_warning") return null;
 
   const tone = state.kind === "check_failed"
@@ -1324,10 +1367,12 @@ export default function SystemDetail() {
   }
 
   const { system, updates, hiddenUpdates, packageIssues, history } = data;
+  const visiblePackageIssues = getVisiblePackageIssuesForCurrentCheck(packageIssues, system.lastCheck);
   const selectionBusy = upgrading || checking || rebooting || repairingPackageIssue || hideUpdate.isPending || unhideUpdate.isPending;
   const packageSelectionState = getPackageSelectionState(selectedPackageNames, updates, selectionBusy);
   const selectedVisiblePackageNames = packageSelectionState.selectedPackageNames;
   const updatesPanelState = getUpdatesPanelState(system, updates.length);
+  const dedupedUpdatesPanelState = dedupePackageIssueUpdateNotice(updatesPanelState, visiblePackageIssues);
   const updateState = deriveSystemUpdateState(system, { upgrading, checking: checking || repairingPackageIssue });
   const dotColor = updateState === "check_failed" || updateState === "unreachable"
     ? "bg-red-500"
@@ -1726,7 +1771,7 @@ export default function SystemDetail() {
       </div>
 
       <PackageManagerIssueBanner
-        issues={packageIssues}
+        issues={visiblePackageIssues}
         busy={upgrading || checking || rebooting || repairingPackageIssue}
         solvingIssueId={solvePackageIssue.isPending ? solvePackageIssue.variables?.issueId ?? null : null}
         dismissingIssueId={dismissPackageIssue.isPending ? dismissPackageIssue.variables?.issueId ?? null : null}
@@ -1788,7 +1833,7 @@ export default function SystemDetail() {
             <AgoLabel timestamp={system.cacheTimestamp} stale={system.isStale} />
           )}
         </div>
-        <UpdateCheckNotice state={updatesPanelState} />
+        <UpdateCheckNotice state={dedupedUpdatesPanelState} />
         {updates.length > 0 ? (
           <UpdatesTable
             updates={updates}

--- a/client/pages/SystemDetail.tsx
+++ b/client/pages/SystemDetail.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from "react-router";
 import { Layout } from "../components/Layout";
 import { AgoLabel } from "../components/AgoLabel";
 import { Badge } from "../components/Badge";
+import { CopyableCodeBlock } from "../components/CopyableCodeBlock";
 import { ConfirmDialog } from "../components/ConfirmDialog";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -246,9 +247,15 @@ function UpdateCheckNotice({
       <p className={`text-sm font-medium ${tone.title}`}>{state.title}</p>
       <p className={`mt-1 text-sm ${tone.body}`}>{state.message}</p>
       {state.error && (
-        <pre className={`mt-3 overflow-x-auto rounded-lg px-3 py-2 text-xs whitespace-pre-wrap ${tone.code}`}>
-          {state.error}
-        </pre>
+        <div className="mt-3">
+          <CopyableCodeBlock
+            text={state.error}
+            className={`overflow-x-auto rounded-lg px-3 py-2 text-xs whitespace-pre-wrap ${tone.code}`}
+            successMessage="Copied check output"
+          >
+            {state.error}
+          </CopyableCodeBlock>
+        </div>
       )}
     </div>
   );
@@ -735,11 +742,13 @@ function StepPanel({
   title,
   children,
   className,
+  copyText,
   followContentKey,
 }: {
   title: string;
   children: React.ReactNode;
   className: string;
+  copyText: string;
   followContentKey?: string;
 }) {
   const containerRef = useRef<HTMLPreElement>(null);
@@ -759,13 +768,15 @@ function StepPanel({
   return (
     <div>
       <p className="text-[10px] uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-1 font-semibold">{title}</p>
-      <pre
+      <CopyableCodeBlock
+        text={copyText}
         ref={containerRef}
         onScroll={followContentKey ? handleScroll : undefined}
         className={className}
+        successMessage={`Copied ${title.toLowerCase()}`}
       >
         {children}
-      </pre>
+      </CopyableCodeBlock>
     </div>
   );
 }
@@ -785,6 +796,7 @@ function LegacyActivityDetails({
         <StepPanel
           title="Command"
           className="text-xs font-mono bg-slate-900 text-slate-200 rounded-lg p-3 overflow-x-auto whitespace-pre-wrap break-all"
+          copyText={command}
         >
           {command}
         </StepPanel>
@@ -793,6 +805,7 @@ function LegacyActivityDetails({
         <StepPanel
           title="Output"
           className="text-xs font-mono bg-slate-900 text-slate-300 rounded-lg p-3 overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap break-all"
+          copyText={output ?? ""}
         >
           {output || <span className="text-slate-500 italic">No output</span>}
         </StepPanel>
@@ -801,6 +814,7 @@ function LegacyActivityDetails({
         <StepPanel
           title="Error"
           className="text-xs font-mono bg-red-950/50 text-red-300 rounded-lg p-3 overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap break-all"
+          copyText={error}
         >
           {error}
         </StepPanel>
@@ -934,6 +948,7 @@ export function ActivityStepViewer({
         <StepPanel
           title="Command"
           className="text-xs font-mono bg-slate-900 text-slate-200 rounded-lg p-3 overflow-x-auto whitespace-pre-wrap break-all"
+          copyText={selectedStep.command}
         >
           {selectedStep.command}
         </StepPanel>
@@ -941,6 +956,7 @@ export function ActivityStepViewer({
         <StepPanel
           title="Output"
           className="text-xs font-mono bg-slate-900 text-slate-300 rounded-lg p-3 overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap break-all"
+          copyText={selectedStep.output ?? ""}
           followContentKey={isLive ? `${selectedIndex}:${selectedStep.output || ""}` : undefined}
         >
           {selectedStep.output || <span className="text-slate-500 italic">No output</span>}
@@ -950,6 +966,7 @@ export function ActivityStepViewer({
           <StepPanel
             title="Error"
             className="text-xs font-mono bg-red-950/50 text-red-300 rounded-lg p-3 overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap break-all"
+            copyText={selectedStep.error}
           >
             {selectedStep.error}
           </StepPanel>

--- a/client/pages/SystemDetail.tsx
+++ b/client/pages/SystemDetail.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect, useMemo } from "react";
+import { useState, useCallback, useRef, useEffect, useLayoutEffect, useMemo } from "react";
 import { useParams, useNavigate } from "react-router";
 import { Layout } from "../components/Layout";
 import { AgoLabel } from "../components/AgoLabel";
@@ -35,6 +35,8 @@ import { getHostKeyStatusText } from "../lib/host-key-status";
 import { formatDurationBetween } from "../lib/time";
 import { highlightShell } from "../lib/shell-highlight";
 import { formatScriptCommand } from "../lib/scripts";
+
+const useBrowserLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 function InfoCard({ title, items }: { title: string; items: { label: string; value: string | null }[] }) {
   return (
@@ -527,6 +529,63 @@ type ActivitySession = {
   packageName?: string;
   packageNames?: string[];
 };
+
+type ActivityScrollAnchor = {
+  key: string;
+  index: number;
+  top: number;
+};
+
+function getVisibleActivityScrollAnchor(container: HTMLDivElement | null): ActivityScrollAnchor | null {
+  if (!container || typeof window === "undefined") return null;
+
+  const rows = Array.from(container.querySelectorAll<HTMLElement>("[data-activity-row-key]"));
+  const viewportTop = 72;
+  const viewportBottom = window.innerHeight;
+
+  for (const [index, row] of rows.entries()) {
+    const rect = row.getBoundingClientRect();
+    if (rect.bottom > viewportTop && rect.top < viewportBottom) {
+      return {
+        key: row.dataset.activityRowKey ?? "",
+        index,
+        top: rect.top,
+      };
+    }
+  }
+
+  return null;
+}
+
+function useActivityScrollAnchor(renderKey: string) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const pendingAnchorRef = useRef<ActivityScrollAnchor | null>(null);
+
+  useBrowserLayoutEffect(() => {
+    const pendingAnchor = pendingAnchorRef.current;
+    if (pendingAnchor?.key && typeof window !== "undefined") {
+      const rows = Array.from(
+        containerRef.current?.querySelectorAll<HTMLElement>("[data-activity-row-key]") ?? [],
+      );
+      const nextAnchor =
+        rows.find((row) => row.dataset.activityRowKey === pendingAnchor.key) ??
+        rows[pendingAnchor.index];
+
+      if (nextAnchor) {
+        const delta = nextAnchor.getBoundingClientRect().top - pendingAnchor.top;
+        if (Math.abs(delta) > 1) {
+          window.scrollBy(0, delta);
+        }
+      }
+    }
+
+    return () => {
+      pendingAnchorRef.current = getVisibleActivityScrollAnchor(containerRef.current);
+    };
+  }, [renderKey]);
+
+  return containerRef;
+}
 
 function getFirstStartedMessage(
   messages: WsMessage[],
@@ -1124,6 +1183,18 @@ function HistoryList({
   });
   const showSynthetic = displayRows.some((row) => row.historyId === null);
   const nowMs = useNowTicker(showSynthetic || !!startedEntry);
+  const activityRenderKey = displayRows
+    .map((row) => [
+      row.key,
+      row.historyId ?? "live",
+      row.status,
+      row.isRunning ? "running" : "done",
+      row.useLiveDetails ? "live-details" : "stored-details",
+      row.steps?.length ?? 0,
+      row.liveSteps.length,
+    ].join(":"))
+    .join("|");
+  const activityScrollRef = useActivityScrollAnchor(activityRenderKey);
 
   // For upgrade-type ops: clear pendingExpand when the "started" DB entry appears.
   useEffect(() => {
@@ -1167,7 +1238,7 @@ function HistoryList({
   }
 
   return (
-    <div className="space-y-1">
+    <div ref={activityScrollRef} className="space-y-1">
       {displayRows.map((row) => {
         const totalRuntime = formatDurationBetween(
           row.startedAt,
@@ -1193,7 +1264,7 @@ function HistoryList({
         const isOpen = expanded.has(row.key);
 
         return (
-          <div key={row.key}>
+          <div key={row.key} data-activity-row-key={row.key}>
             <button
               type="button"
               onClick={() => hasDetails && toggle(row.key)}

--- a/client/pages/SystemDetail.tsx
+++ b/client/pages/SystemDetail.tsx
@@ -853,7 +853,7 @@ function ShellCommandPanel({ command }: { command: string }) {
   return (
     <StepPanel
       title="Command"
-      className="script-code text-xs font-mono bg-slate-900 rounded-lg p-3 overflow-x-auto whitespace-pre-wrap break-words"
+      className="script-code text-xs font-mono bg-slate-900 rounded-lg p-3 overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap break-words"
       copyText={displayCommand}
     >
       <code dangerouslySetInnerHTML={{ __html: highlighted }} />

--- a/client/pages/SystemDetail.tsx
+++ b/client/pages/SystemDetail.tsx
@@ -5,6 +5,7 @@ import { AgoLabel } from "../components/AgoLabel";
 import { Badge } from "../components/Badge";
 import { CopyableCodeBlock } from "../components/CopyableCodeBlock";
 import { ConfirmDialog } from "../components/ConfirmDialog";
+import { TerminalText } from "../components/TerminalText";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   useSystem,
@@ -860,6 +861,39 @@ function ShellCommandPanel({ command }: { command: string }) {
   );
 }
 
+function TerminalOutputPanel({
+  title,
+  output,
+  emptyText = "No output",
+  followContentKey,
+  tone = "default",
+}: {
+  title: string;
+  output: string | null;
+  emptyText?: string;
+  followContentKey?: string;
+  tone?: "default" | "error";
+}) {
+  return (
+    <StepPanel
+      title={title}
+      className={`text-xs font-mono rounded-lg p-3 overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap break-all ${
+        tone === "error"
+          ? "bg-red-950/50 text-red-300"
+          : "bg-slate-900 text-slate-300"
+      }`}
+      copyText={output ?? ""}
+      followContentKey={followContentKey}
+    >
+      {output ? (
+        <TerminalText text={output} stream={tone === "error" ? "stderr" : "stdout"} />
+      ) : (
+        <span className="text-slate-500 italic">{emptyText}</span>
+      )}
+    </StepPanel>
+  );
+}
+
 function LegacyActivityDetails({
   command,
   output,
@@ -875,22 +909,17 @@ function LegacyActivityDetails({
         <ShellCommandPanel command={command} />
       )}
       {(command || output) && (
-        <StepPanel
+        <TerminalOutputPanel
           title="Output"
-          className="text-xs font-mono bg-slate-900 text-slate-300 rounded-lg p-3 overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap break-all"
-          copyText={output ?? ""}
-        >
-          {output || <span className="text-slate-500 italic">No output</span>}
-        </StepPanel>
+          output={output}
+        />
       )}
       {error && (
-        <StepPanel
+        <TerminalOutputPanel
           title="Error"
-          className="text-xs font-mono bg-red-950/50 text-red-300 rounded-lg p-3 overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap break-all"
-          copyText={error}
-        >
-          {error}
-        </StepPanel>
+          output={error}
+          tone="error"
+        />
       )}
     </>
   );
@@ -1020,23 +1049,18 @@ export function ActivityStepViewer({
 
         <ShellCommandPanel command={selectedStep.command} />
 
-        <StepPanel
+        <TerminalOutputPanel
           title="Output"
-          className="text-xs font-mono bg-slate-900 text-slate-300 rounded-lg p-3 overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap break-all"
-          copyText={selectedStep.output ?? ""}
+          output={selectedStep.output}
           followContentKey={isLive ? `${selectedIndex}:${selectedStep.output || ""}` : undefined}
-        >
-          {selectedStep.output || <span className="text-slate-500 italic">No output</span>}
-        </StepPanel>
+        />
 
         {selectedStep.error && (
-          <StepPanel
+          <TerminalOutputPanel
             title="Error"
-            className="text-xs font-mono bg-red-950/50 text-red-300 rounded-lg p-3 overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap break-all"
-            copyText={selectedStep.error}
-          >
-            {selectedStep.error}
-          </StepPanel>
+            output={selectedStep.error}
+            tone="error"
+          />
         )}
       </div>
     </div>

--- a/client/pages/SystemDetail.tsx
+++ b/client/pages/SystemDetail.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { useParams, useNavigate } from "react-router";
 import { Layout } from "../components/Layout";
 import { AgoLabel } from "../components/AgoLabel";
@@ -32,6 +32,8 @@ import { deriveSystemUpdateState, getUpdatesPanelState, isPostUpgradeRecheck, sh
 import { getUpgradeBehaviorNotes } from "../lib/package-manager-configs";
 import { getHostKeyStatusText } from "../lib/host-key-status";
 import { formatDurationBetween } from "../lib/time";
+import { highlightShell } from "../lib/shell-highlight";
+import { formatScriptCommand } from "../lib/scripts";
 
 function InfoCard({ title, items }: { title: string; items: { label: string; value: string | null }[] }) {
   return (
@@ -824,6 +826,40 @@ function StepPanel({
   );
 }
 
+function ShellCommandPanel({ command }: { command: string }) {
+  const [displayCommand, setDisplayCommand] = useState(command);
+
+  useEffect(() => {
+    let cancelled = false;
+    setDisplayCommand(command);
+    if (!command.trim()) return;
+
+    formatScriptCommand(command)
+      .then((formatted) => {
+        if (!cancelled) setDisplayCommand(formatted);
+      })
+      .catch(() => {
+        if (!cancelled) setDisplayCommand(command);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [command]);
+
+  const highlighted = useMemo(() => highlightShell(displayCommand), [displayCommand]);
+
+  return (
+    <StepPanel
+      title="Command"
+      className="script-code text-xs font-mono bg-slate-900 rounded-lg p-3 overflow-x-auto whitespace-pre-wrap break-words"
+      copyText={displayCommand}
+    >
+      <code dangerouslySetInnerHTML={{ __html: highlighted }} />
+    </StepPanel>
+  );
+}
+
 function LegacyActivityDetails({
   command,
   output,
@@ -836,13 +872,7 @@ function LegacyActivityDetails({
   return (
     <>
       {command && (
-        <StepPanel
-          title="Command"
-          className="text-xs font-mono bg-slate-900 text-slate-200 rounded-lg p-3 overflow-x-auto whitespace-pre-wrap break-all"
-          copyText={command}
-        >
-          {command}
-        </StepPanel>
+        <ShellCommandPanel command={command} />
       )}
       {(command || output) && (
         <StepPanel
@@ -988,13 +1018,7 @@ export function ActivityStepViewer({
           </span>
         </div>
 
-        <StepPanel
-          title="Command"
-          className="text-xs font-mono bg-slate-900 text-slate-200 rounded-lg p-3 overflow-x-auto whitespace-pre-wrap break-all"
-          copyText={selectedStep.command}
-        >
-          {selectedStep.command}
-        </StepPanel>
+        <ShellCommandPanel command={selectedStep.command} />
 
         <StepPanel
           title="Output"

--- a/client/pages/SystemDetail.tsx
+++ b/client/pages/SystemDetail.tsx
@@ -879,7 +879,7 @@ function TerminalOutputPanel({
       title={title}
       className={`text-xs font-mono rounded-lg p-3 overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap break-all ${
         tone === "error"
-          ? "bg-red-950/50 text-red-300"
+          ? "bg-red-950 text-red-100 dark:bg-red-950/50 dark:text-red-200"
           : "bg-slate-900 text-slate-300"
       }`}
       copyText={output ?? ""}

--- a/server/services/script-service.ts
+++ b/server/services/script-service.ts
@@ -12,7 +12,7 @@ import {
 } from "../package-manager-configs";
 import { getPackageManagerDetectionCommands } from "../ssh/detector";
 import { getParser, type ParsedUpdate } from "../ssh/parsers";
-import { APT_DPKG_AUDIT_PREFIX } from "../ssh/parsers/apt";
+import { APT_REFRESH_COMMAND } from "../ssh/parsers/apt";
 import type { CheckCommandResult } from "../ssh/parsers/types";
 import { sudo, validatePackageName, validatePackageNames } from "../ssh/parsers/types";
 import { getProxmoxBackupGuardCommand, getRebootCommand } from "../ssh/reboot";
@@ -737,7 +737,7 @@ function builtinCheckSteps(manager: string): ScriptStep[] {
           label: "Fetching package lists",
           command: commentedCommand(
             "Audit dpkg state, then refresh APT package metadata before listing available updates.",
-            `${APT_DPKG_AUDIT_PREFIX}; ${sudo("apt-get -o DPkg::Lock::Timeout=60 update -qq")} 2>&1`,
+            APT_REFRESH_COMMAND,
           ),
         },
         {

--- a/server/ssh/parsers/apt.ts
+++ b/server/ssh/parsers/apt.ts
@@ -49,15 +49,44 @@ function findCommandResult(
 }
 
 export const APT_LOCK_WAIT = "-o DPkg::Lock::Timeout=60";
-export const APT_DPKG_AUDIT_PREFIX =
-  'audit="$(dpkg --audit 2>&1 || true)"; if [ -n "$audit" ]; then printf "%s\\n" "dpkg was interrupted, you must manually run \'sudo dpkg --configure -a\' to correct the problem."; printf "%s\\n" "$audit"; fi';
+
+export const APT_DPKG_AUDIT_SCRIPT = [
+  'audit="$(dpkg --audit 2>&1)"',
+  "audit_rc=$?",
+  'if [ "$audit_rc" -ne 0 ]; then',
+  '  printf "%s\\n" "$audit"',
+  '  exit "$audit_rc"',
+  "fi",
+  'if [ -n "$audit" ]; then',
+  `  printf "%s\\n" "dpkg was interrupted, you must manually run 'sudo dpkg --configure -a' to correct the problem."`,
+  '  printf "%s\\n" "$audit"',
+  "fi",
+  `apt-get ${APT_LOCK_WAIT} update -qq`,
+].join("\n");
+
+export const APT_REFRESH_COMMAND = [
+  'apt_check_script="$(mktemp /tmp/ludash_apt_check_XXXXXX.sh)"',
+  'cleanup() { rm -f "$apt_check_script"; }',
+  "trap cleanup EXIT HUP INT TERM",
+  'cat > "$apt_check_script" <<\'LUDASH_APT_CHECK\'',
+  APT_DPKG_AUDIT_SCRIPT,
+  "LUDASH_APT_CHECK",
+  'chmod 700 "$apt_check_script"',
+  'if [ "$(id -u)" = "0" ]; then',
+  '  sh "$apt_check_script"',
+  "elif command -v sudo >/dev/null 2>&1; then",
+  `  sudo -S -p '' sh "$apt_check_script"`,
+  "else",
+  '  sh "$apt_check_script"',
+  "fi 2>&1",
+].join("\n");
 
 export const aptParser: PackageParser = {
   name: "apt",
 
   getCheckCommands() {
     return [
-      `${APT_DPKG_AUDIT_PREFIX}; ${sudo(`apt-get ${APT_LOCK_WAIT} update -qq`)} 2>&1`,
+      APT_REFRESH_COMMAND,
       "DEBIAN_FRONTEND=noninteractive apt list --upgradable 2>/dev/null | tail -n +2",
       "DEBIAN_FRONTEND=noninteractive apt-get -s -o Debug::NoLocking=1 upgrade 2>&1",
     ];

--- a/tests/client/activity-step-viewer.test.tsx
+++ b/tests/client/activity-step-viewer.test.tsx
@@ -49,4 +49,21 @@ describe("ActivityStepViewer", () => {
     expect(html).not.toContain("Runtime 1m 5s");
     expect(html).toContain("Listing available updates");
   });
+
+  test("syntax highlights shell commands", () => {
+    const html = renderToStaticMarkup(
+      <ActivityStepViewer
+        viewerId="highlighted-step"
+        steps={[
+          {
+            ...baseStep,
+            command: "# Fetch package lists\napt-get update",
+          },
+        ]}
+      />
+    );
+
+    expect(html).toContain("script-code");
+    expect(html).toContain("hljs-comment");
+  });
 });

--- a/tests/client/activity-step-viewer.test.tsx
+++ b/tests/client/activity-step-viewer.test.tsx
@@ -66,4 +66,13 @@ describe("ActivityStepViewer", () => {
     expect(html).toContain("script-code");
     expect(html).toContain("hljs-comment");
   });
+
+  test("caps command panes to match output panes", () => {
+    const html = renderToStaticMarkup(
+      <ActivityStepViewer viewerId="single-step" steps={[baseStep]} />
+    );
+
+    expect(html).toContain("script-code");
+    expect(html).toContain("max-h-64 overflow-y-auto");
+  });
 });

--- a/tests/client/scripts-page.test.tsx
+++ b/tests/client/scripts-page.test.tsx
@@ -40,6 +40,7 @@ vi.mock("../../client/lib/scripts", async () => {
 
 vi.mock("../../client/context/ToastContext", () => ({
   useToast: mockUseToast,
+  useOptionalToast: mockUseToast,
 }));
 
 vi.mock("../../client/components/Layout", () => ({

--- a/tests/client/system-detail-activity.test.ts
+++ b/tests/client/system-detail-activity.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
   buildActivityDisplayRows,
+  dedupePackageIssueUpdateNotice,
   getActivityTitle,
   getPackageSelectionState,
+  getVisiblePackageIssuesForCurrentCheck,
   isScrollNearBottom,
   matchesHistoryEntryToSession,
   PackageManagerIssueBanner,
@@ -455,26 +457,26 @@ describe("buildActivityDisplayRows", () => {
 });
 
 describe("PackageManagerIssueBanner", () => {
-  test("renders solve and dismiss actions for visible package manager issues", () => {
-    const issue: PackageManagerIssue = {
-      id: 7,
-      systemId: 1,
-      pkgManager: "apt",
-      issueKey: "apt_dpkg_interrupted",
-      title: "APT needs repair",
-      message: "dpkg was interrupted",
-      repairCommand: "dpkg --configure -a",
-      active: 1,
-      dismissedBootId: null,
-      dismissedUptimeSeconds: null,
-      dismissedAt: null,
-      detectedAt: "2026-05-17 10:00:00",
-      lastSeenAt: "2026-05-17 10:00:00",
-      resolvedAt: null,
-      createdAt: "2026-05-17 10:00:00",
-      updatedAt: "2026-05-17 10:00:00",
-    };
+  const issue: PackageManagerIssue = {
+    id: 7,
+    systemId: 1,
+    pkgManager: "apt",
+    issueKey: "apt_dpkg_interrupted",
+    title: "APT needs repair",
+    message: "dpkg was interrupted. Run dpkg --configure -a to finish pending package configuration before checking for updates again.",
+    repairCommand: "dpkg --configure -a",
+    active: 1,
+    dismissedBootId: null,
+    dismissedUptimeSeconds: null,
+    dismissedAt: null,
+    detectedAt: "2026-05-17 10:00:00",
+    lastSeenAt: "2026-05-17 10:00:00",
+    resolvedAt: null,
+    createdAt: "2026-05-17 10:00:00",
+    updatedAt: "2026-05-17 10:00:00",
+  };
 
+  test("renders solve and dismiss actions for visible package manager issues", () => {
     const html = renderToStaticMarkup(PackageManagerIssueBanner({
       issues: [issue],
       onSolve: () => {},
@@ -485,6 +487,40 @@ describe("PackageManagerIssueBanner", () => {
     expect(html).toContain("dpkg was interrupted");
     expect(html).toContain("Solve");
     expect(html).toContain("Dismiss");
+  });
+
+  test("hides update warning when package issue banner already shows the same warning", () => {
+    const state = dedupePackageIssueUpdateNotice({
+      kind: "check_warning",
+      title: "Update check completed with warnings",
+      message: "Showing the updates that were found before one or more package manager checks failed.",
+      error: `[apt] ${issue.message}`,
+    }, [issue]);
+
+    expect(state).toBeNull();
+  });
+
+  test("keeps unrelated update warning text after removing package issue duplicate", () => {
+    const state = dedupePackageIssueUpdateNotice({
+      kind: "check_warning",
+      title: "Update check completed with warnings",
+      message: "Showing the updates that were found before one or more package manager checks failed.",
+      error: `[apt] ${issue.message}\n\n[flatpak] remote metadata refresh failed`,
+    }, [issue]);
+
+    expect(state).toMatchObject({
+      kind: "check_warning",
+      error: "[flatpak] remote metadata refresh failed",
+    });
+  });
+
+  test("hides package issue actions while sudo credentials block the latest check", () => {
+    expect(getVisiblePackageIssuesForCurrentCheck([issue], {
+      status: "failed",
+      error: "[apt] sudo: a password is required",
+      startedAt: "2026-05-17 10:00:00",
+      completedAt: "2026-05-17 10:00:01",
+    })).toEqual([]);
   });
 });
 

--- a/tests/client/terminal-text.test.tsx
+++ b/tests/client/terminal-text.test.tsx
@@ -1,0 +1,65 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import { TerminalOutput } from "../../client/components/TerminalOutput";
+import { TerminalText, parseTerminalText } from "../../client/components/TerminalText";
+
+describe("TerminalText", () => {
+  test("renders ANSI colors without exposing escape sequences", () => {
+    const html = renderToStaticMarkup(
+      <TerminalText text={"\x1b[31mFailed\x1b[0m\n"} />
+    );
+
+    expect(html).toContain("text-red-400");
+    expect(html).toContain("Failed");
+    expect(html).not.toContain("[31m");
+  });
+
+  test("does not color plain package-manager words", () => {
+    const html = renderToStaticMarkup(
+      <TerminalText text={"34 upgraded, 0 newly installed, 0 to remove\n"} />
+    );
+
+    expect(html).toContain("34 upgraded");
+    expect(html).not.toContain("text-green-400");
+    expect(html).not.toContain("font-semibold");
+  });
+
+  test("colors stderr output as an error stream", () => {
+    const html = renderToStaticMarkup(
+      <TerminalText text={"warning: package kept back\n"} stream="stderr" />
+    );
+
+    expect(html).toContain("text-red-400");
+  });
+
+  test("parses ANSI chunks for live output rendering", () => {
+    expect(parseTerminalText("ok \x1b[32mdone\x1b[0m")[1]).toMatchObject({
+      text: "done",
+      classes: ["text-green-400"],
+      hasColor: true,
+    });
+  });
+});
+
+describe("TerminalOutput", () => {
+  test("renders live output through terminal text styling", () => {
+    const html = renderToStaticMarkup(
+      <TerminalOutput
+        messages={[
+          {
+            type: "output",
+            data: "\x1b[33mwarning\x1b[0m: reboot required\n",
+            stream: "stdout",
+          },
+        ]}
+        isActive={true}
+        phase={null}
+        connected={true}
+      />
+    );
+
+    expect(html).toContain("text-amber-300");
+    expect(html).toContain("warning");
+    expect(html).not.toContain("[33m");
+  });
+});

--- a/tests/server/package-manager-issues.test.ts
+++ b/tests/server/package-manager-issues.test.ts
@@ -140,6 +140,31 @@ describe("package manager issues", () => {
     expect(issues[0].repairCommand).toContain("dpkg --configure -a");
   });
 
+  test("does not detect interrupted dpkg when apt audit cannot read dpkg state", async () => {
+    const systemId = createAptSystem();
+    const sshManager = initSSHManager(1, 1, 1, getEncryptor());
+
+    (sshManager as any).connect = async () => ({});
+    (sshManager as any).disconnect = () => {};
+    (sshManager as any).runCommand = async (_conn: unknown, command: string) => {
+      if (command === SYSTEM_INFO_CMD) {
+        return { stdout: SYSTEM_INFO_OUTPUT, stderr: "", exitCode: 0 };
+      }
+      if (command.includes("apt-get -o DPkg::Lock::Timeout=60 update -qq")) {
+        return {
+          stdout: "dpkg: error: unable to check lock file for dpkg database directory /var/lib/dpkg: Permission denied\n",
+          stderr: "",
+          exitCode: 2,
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    };
+
+    await expect(checkUpdates(systemId)).rejects.toThrow("Permission denied");
+
+    expect(listVisiblePackageManagerIssues(systemId)).toHaveLength(0);
+  });
+
   test("detects interrupted dpkg from successful apt audit output while keeping updates", async () => {
     const systemId = createAptSystem();
     const sshManager = initSSHManager(1, 1, 1, getEncryptor());

--- a/tests/server/parsers.test.ts
+++ b/tests/server/parsers.test.ts
@@ -76,6 +76,9 @@ describe("AptParser", () => {
     expect(cmds).toHaveLength(3);
     expect(cmds[0]).toContain("apt-get");
     expect(cmds[0]).toContain("update");
+    expect(cmds[0]).toContain("dpkg --audit");
+    expect(cmds[0]).toContain("sudo -S -p '' sh \"$apt_check_script\"");
+    expect(cmds[0]).toContain("LUDASH_APT_CHECK");
     expect(cmds[2]).toContain("Debug::NoLocking=1");
   });
 

--- a/tests/server/script-service.test.ts
+++ b/tests/server/script-service.test.ts
@@ -26,6 +26,7 @@ import {
   updateScript,
   updateCustomPackageManager,
 } from "../../server/services/script-service";
+import { APT_REFRESH_COMMAND } from "../../server/ssh/parsers/apt";
 
 describe("script service", () => {
   let tempDir: string;
@@ -73,6 +74,16 @@ describe("script service", () => {
     expect(scripts.some((script) => script.id === "builtin:snap:detect" && script.readonly)).toBe(true);
     expect(scripts.some((script) => script.id === "builtin:system:system_info" && script.readonly)).toBe(true);
     expect(scripts.some((script) => script.id === "builtin:system:reboot" && script.readonly)).toBe(true);
+  });
+
+  test("shows the elevated APT audit refresh command in built-in scripts", () => {
+    const checkApt = getBuiltinScripts().find((script) => script.id === "builtin:apt:check_updates");
+
+    expect(checkApt?.steps[0]?.command).toContain(APT_REFRESH_COMMAND);
+    expect(checkApt?.steps[0]?.command).toContain("sudo -S -p '' sh \"$apt_check_script\"");
+    expect(checkApt?.steps[0]?.command).toContain("LUDASH_APT_CHECK");
+    expect(checkApt?.steps[0]?.command).toContain("dpkg --audit 2>&1");
+    expect(checkApt?.steps[0]?.command).not.toContain("dpkg --audit 2>&1 || true");
   });
 
   test("resolves built-in runtime steps from the canonical script templates", () => {
@@ -529,14 +540,20 @@ describe("script service", () => {
 
   test("formats compact built-in shell commands for display", async () => {
     const aptUpgrade = getBuiltinScripts().find((script) => script.id === "builtin:apt:upgrade_all");
+    const aptCheck = getBuiltinScripts().find((script) => script.id === "builtin:apt:check_updates");
     const reboot = getBuiltinScripts().find((script) => script.id === "builtin:system:reboot");
 
     const formattedApt = await formatShellCommand(aptUpgrade?.steps[0]?.command ?? "");
+    const formattedAptCheck = await formatShellCommand(aptCheck?.steps[0]?.command ?? "");
     const formattedRebootGuard = await formatShellCommand(reboot?.steps[0]?.command ?? "");
     const formattedReboot = await formatShellCommand(reboot?.steps[1]?.command ?? "");
 
     expect(formattedApt).toContain('if [ "$upgrade_mode" != "full-upgrade" ]; then\n  upgrade_mode="upgrade"\nfi');
     expect(formattedApt).toContain('elif command -v sudo > /dev/null 2>&1; then\n  sudo -S -p');
+    expect(formattedAptCheck).toContain("Audit dpkg state, then refresh APT package metadata before listing available updates.");
+    expect(formattedAptCheck).toContain('audit="$(dpkg --audit 2>&1)"');
+    expect(formattedAptCheck).toContain("LUDASH_APT_CHECK");
+    expect(formattedAptCheck).toContain("sudo -S -p");
     expect(reboot?.steps.map((step) => step.label)).toEqual([
       "Pre-reboot safety checks",
       "Reboot system",


### PR DESCRIPTION
- Add copy buttons to command output blocks
- Fix APT audit sudo check
- Highlight and beautify executed commands
- Render terminal output with ANSI colors
- Improve activity error contrast
- Limit activity command pane height
- Fix activity history scroll jump