### PR TITLE
Enhance dashboard with banners and fix UI issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,7 +840,7 @@ The project includes Docker-based test systems that simulate real Linux servers 
 This will:
 
 1. Stop any running dev/production services
-2. Build and start 15 Docker containers (including Alpine, fish-shell, sudo-password APT, and partial multi-manager fixtures)
+2. Build and start 16 Docker containers (including Alpine, fish-shell, sudo-password APT, root-login APT, full-sudo APT, and partial multi-manager fixtures)
 3. Build the frontend in production mode
 4. Start the production server on `:3001`
 
@@ -850,9 +850,10 @@ The server initializes or upgrades the SQLite schema automatically during startu
 
 - User: `testuser`
 - Password: `testpass`
+- `ludash-test-ubuntu-root` also accepts `root` / `testpass`; use that login to exercise the root-user info banner
 - `Sudo password`: `testpass` (required for `ludash-test-ubuntu-sudo` and `ludash-test-debian-fish-sudo`, optional for others)
-- Every `testuser` account is restricted to the package-manager maintenance commands needed by its fixture; arbitrary commands such as `sudo -n true` are denied
-- Passwordless `sudo` is pre-configured for the restricted allowlists except on `ludash-test-ubuntu-sudo` and `ludash-test-debian-fish-sudo`
+- Every `testuser` account is restricted to the package-manager maintenance commands needed by its fixture except `ludash-test-ubuntu-root`, which intentionally grants unrestricted sudo for root-permission testing
+- Passwordless `sudo` is pre-configured for the restricted allowlists and for `ludash-test-ubuntu-root`; `ludash-test-ubuntu-sudo` and `ludash-test-debian-fish-sudo` require the sudo password
 
 | Container                          | SSH Port | Package Manager                | Login Shell | Base Image   |
 | ---------------------------------- | -------- | ------------------------------ | ----------- | ------------ |
@@ -871,6 +872,7 @@ The server initializes or upgrades the SQLite schema automatically during startu
 | `ludash-test-dnf-gpg-prompt`       | 2013     | DNF (GPG key prompt fixture)   | `bash`      | Fedora 41    |
 | `ludash-test-dnf-eula-prompt`      | 2014     | DNF (EULA prompt fixture)      | `bash`      | Fedora 41    |
 | `ludash-test-apt-dpkg-interrupted` | 2015     | APT (interrupted dpkg fixture) | `bash`      | Debian 12    |
+| `ludash-test-ubuntu-root`          | 2016     | APT (root login/full sudo)     | `bash`      | Ubuntu 24.04 |
 
 To add a test system in the dashboard, use `host.docker.internal` (or `172.17.0.1` on Linux) as the hostname with the corresponding SSH port.
 
@@ -910,7 +912,9 @@ That makes it useful for verifying the dashboard’s opt-in DNF/YUM EULA automat
 
 That makes it useful for verifying the package manager issue banner, including the **Solve** action that runs `dpkg --configure -a` and then rechecks updates.
 
-All test systems use dedicated least-privilege `testuser` accounts. Their reusable package-manager allowlists live under [`docker/test-systems/sudoers/`](docker/test-systems/sudoers/). Selected-package operations use reviewed argument wildcards where a fixture needs to exercise arbitrary package choices. DNF/YUM fixtures allow only the exact `env ACCEPT_EULA=Y` upgrade forms used by their opt-in EULA setting.
+`ludash-test-ubuntu-root` is a special APT fixture where `root` can log in over SSH with password `testpass`, and `testuser` has unrestricted passwordless sudo through [`root-nopasswd`](docker/test-systems/sudoers/root-nopasswd). Add it to the dashboard as `root` to verify the root-user info banner, or as `testuser` to verify broad sudo behavior without triggering that banner.
+
+All other test systems use dedicated least-privilege `testuser` accounts. Their reusable package-manager allowlists live under [`docker/test-systems/sudoers/`](docker/test-systems/sudoers/). Selected-package operations use reviewed argument wildcards where a fixture needs to exercise arbitrary package choices. DNF/YUM fixtures allow only the exact `env ACCEPT_EULA=Y` upgrade forms used by their opt-in EULA setting.
 
 To verify that password-based sudo receives credentials for each atomic APT
 check step, run the fish-shell fixture integration test:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Detailed system view with connection data, OS and resource information, availabl
 
 ### Systems List
 
-Table view of all configured systems with OS, status, update counts, last check time, and quick actions.
+Table view of all configured systems with OS, status badges, last check time, and quick actions.
 
 ![Systems List](screenshots/3.png)
 
@@ -935,7 +935,7 @@ To reset the `dev` branch to match `main` (force push):
 
 ## API Overview
 
-All endpoints require authentication unless noted. Responses are JSON.
+All HTTP endpoints require authentication unless noted. Responses are JSON.
 
 ### Health
 
@@ -981,9 +981,11 @@ All endpoints require authentication unless noted. Responses are JSON.
 | POST   | `/api/systems/test-connection`                     | Test SSH connectivity                                           |
 | POST   | `/api/systems/:id/reboot`                          | Reboot a system                                                 |
 | POST   | `/api/systems/:id/dismiss-needs-reboot`            | Dismiss a stale reboot-needed indicator                         |
+| POST   | `/api/systems/:id/dismiss-root-user-banner`        | Dismiss the root-user info banner for a system                  |
 | POST   | `/api/systems/:id/revoke-host-key`                 | Clear the stored trusted host key                               |
 | PUT    | `/api/systems/:id/script-overrides`                | Update per-system script overrides                              |
 | DELETE | `/api/systems/:id`                                 | Remove a system                                                 |
+| GET    | `/api/systems/:id/sudoers-preview`                 | Generate least-privilege sudoers setup instructions             |
 | GET    | `/api/systems/:id/updates`                         | Cached updates for a system                                     |
 | GET    | `/api/systems/:id/history`                         | Upgrade history for a system                                    |
 | POST   | `/api/systems/:id/hidden-updates`                  | Hide one visible update from counts and dashboards              |
@@ -1085,6 +1087,12 @@ All endpoints require authentication unless noted. Responses are JSON.
 | GET    | `/api/dashboard/systems` | All systems with status metadata |
 | GET    | `/api/settings`          | Current settings                 |
 | PUT    | `/api/settings`          | Update settings                  |
+
+### WebSocket
+
+| Endpoint                         | Description                                |
+| -------------------------------- | ------------------------------------------ |
+| `/api/ws/systems/:id/output`     | Live command output stream for one system  |
 
 ## Security
 

--- a/client/components/CopyableCodeBlock.tsx
+++ b/client/components/CopyableCodeBlock.tsx
@@ -203,7 +203,7 @@ export const CopyableCodeBlock = forwardRef<
 
   return (
     <div className="relative">
-      <div className="absolute right-2 top-2 z-10 flex gap-1">
+      <div className="absolute right-2 top-2 z-[1] flex gap-1">
         {expandable && canExpand && (
           <ContentExpansionButton expanded={expanded} onToggle={toggleExpanded} />
         )}

--- a/client/components/systems/SystemForm.tsx
+++ b/client/components/systems/SystemForm.tsx
@@ -695,11 +695,11 @@ export function SystemForm({
               </div>
               <div className="flex flex-wrap items-center justify-end gap-2 sm:shrink-0">
                 {storedHostKeyNeedsAttention ? (
-                  <Badge variant="danger" small>{getHostKeyStatusBadgeLabel("needs_approval")}</Badge>
+                  <Badge variant="warning" small>{getHostKeyStatusBadgeLabel("needs_approval")}</Badge>
                 ) : approvedHostKey ? (
                   <Badge variant="success" small>{getHostKeyStatusBadgeLabel("verified")}</Badge>
                 ) : (
-                  <Badge variant="info" small>{getHostKeyStatusBadgeLabel("needs_approval")}</Badge>
+                  <Badge variant="warning" small>{getHostKeyStatusBadgeLabel("needs_approval")}</Badge>
                 )}
               {hasPendingHostKeyReview && pendingReviewShowsMultipleHosts && (
                 <Badge variant="muted" small>{`${pendingChallengeCount}\u00A0keys`}</Badge>
@@ -742,7 +742,7 @@ export function SystemForm({
               </div>
             </div>
             {storedHostKeyNeedsAttention && !hasPendingHostKeyReview && (
-              <div className="rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-300">
+              <div className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-300">
                 The stored SSH host key no longer matches what this host presented during the latest check.
                 Review and re-approve the current host key before running SSH actions again.
               </div>
@@ -757,7 +757,7 @@ export function SystemForm({
                     : "Review the fetched host key below and approve it only if these details match what you expect for this host."}
                 </div>
                 {fetchedHostKeyDiffersFromApproved && (
-                  <div className="rounded-lg border border-red-300 bg-red-50 px-3 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-300">
+                  <div className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-3 text-sm text-amber-700 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-300">
                     <div className="font-medium">The approved host key does not match the current host key.</div>
                     <div className="mt-3 grid gap-3 sm:grid-cols-2">
                       <div>

--- a/client/lib/system-status.ts
+++ b/client/lib/system-status.ts
@@ -29,6 +29,9 @@ export type UpdatesPanelState =
   | { kind: "updates_available" }
   | { kind: "up_to_date" };
 
+const HOST_KEY_VERIFICATION_ERROR_RE =
+  /HostKeyV(?:erification|arification)Error|SSH host key approval required|SSH host key verification failed/i;
+
 export function isPostUpgradeRecheck(activeOperation: ActiveOperation | null | undefined): boolean {
   return activeOperation?.phase === "rechecking" && activeOperation.type.includes("upgrade");
 }
@@ -39,6 +42,29 @@ export function isPostAutoremoveRecheck(activeOperation: ActiveOperation | null 
 
 export function shouldClearLocalUpgrade(activeOperation: ActiveOperation | null | undefined): boolean {
   return !activeOperation || isPostUpgradeRecheck(activeOperation);
+}
+
+export function isHostKeyVerificationErrorMessage(message: string | null | undefined): boolean {
+  return HOST_KEY_VERIFICATION_ERROR_RE.test(message ?? "");
+}
+
+export function hasHostKeyVerificationError(lastCheck: LastCheckSummary | null | undefined): boolean {
+  return isHostKeyVerificationErrorMessage(lastCheck?.error);
+}
+
+export function omitHostKeyVerificationErrorFromUpdatesPanelState(
+  state: UpdatesPanelState | null,
+): UpdatesPanelState | null {
+  if (!state || (state.kind !== "check_failed" && state.kind !== "check_warning")) return state;
+  if (!isHostKeyVerificationErrorMessage(state.error)) return state;
+
+  const remainingErrors = (state.error ?? "")
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter((block) => !isHostKeyVerificationErrorMessage(block));
+
+  if (remainingErrors.length === 0) return null;
+  return { ...state, error: remainingErrors.join("\n\n") };
 }
 
 export function deriveSystemUpdateState(

--- a/client/lib/systems.ts
+++ b/client/lib/systems.ts
@@ -55,6 +55,8 @@ export interface System {
   rebootDismissedBootId: string | null;
   rebootDismissedUptimeSeconds: number | null;
   rebootDismissedAt: string | null;
+  rootUserBannerDismissed: number;
+  rootUserBannerDismissedHostKeyFingerprintSha256: string | null;
   excludeFromUpgradeAll: number;
   upgradeGroupId: number | null;
   upgradeOrder: number;
@@ -225,6 +227,28 @@ export interface SudoersPreview {
   resolutionError: string | null;
   content: string;
   warnings: SudoersPreviewWarning[];
+}
+
+export interface ApprovedHostKeyApproval {
+  systemId?: number;
+  role: "jump" | "target";
+  host: string;
+  port: number;
+  algorithm: string;
+  fingerprintSha256: string;
+  rawKey: string;
+}
+
+export function getApprovedHostKeyInvalidationSystemIds(
+  approvedHostKeys: ApprovedHostKeyApproval[] | undefined,
+): number[] {
+  const systemIds = new Set<number>();
+  for (const approvedHostKey of approvedHostKeys ?? []) {
+    if (typeof approvedHostKey.systemId === "number") {
+      systemIds.add(approvedHostKey.systemId);
+    }
+  }
+  return [...systemIds];
 }
 
 export interface SystemDetailResponse {
@@ -525,6 +549,18 @@ export function useDismissNeedsReboot() {
   });
 }
 
+export function useDismissRootUserBanner() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) =>
+      apiFetch<{ status: string }>(`/systems/${id}/dismiss-root-user-banner`, { method: "POST" }),
+    onSuccess: async (_data, id) => {
+      await qc.invalidateQueries({ queryKey: ["system", id] });
+      await qc.invalidateQueries({ queryKey: ["systems"] });
+    },
+  });
+}
+
 export function useSolvePackageIssue() {
   const qc = useQueryClient();
   return useMutation({
@@ -561,6 +597,7 @@ export function useDismissPackageIssue() {
 }
 
 export function useTestConnection() {
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: (data: {
       hostname: string;
@@ -569,15 +606,7 @@ export function useTestConnection() {
       proxyJumpSystemId?: number | null;
       hostKeyVerificationEnabled?: boolean;
       trustChallengeToken?: string;
-      approvedHostKeys?: Array<{
-        systemId?: number;
-        role: "jump" | "target";
-        host: string;
-        port: number;
-        algorithm: string;
-        fingerprintSha256: string;
-        rawKey: string;
-      }>;
+      approvedHostKeys?: ApprovedHostKeyApproval[];
       systemId?: number;
       sourceSystemId?: number;
     }) =>
@@ -601,6 +630,15 @@ export function useTestConnection() {
         "/systems/test-connection",
         { method: "POST", body: JSON.stringify(data) }
       ),
+    onSuccess: async (_data, vars) => {
+      const systemIds = getApprovedHostKeyInvalidationSystemIds(vars.approvedHostKeys);
+      if (!systemIds.length) return;
+
+      await Promise.all(systemIds.map((id) =>
+        qc.invalidateQueries({ queryKey: ["system", id] })
+      ));
+      await qc.invalidateQueries({ queryKey: ["systems"] });
+    },
   });
 }
 

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -74,7 +74,7 @@ function compareSystemsInGroup(a: System, b: System): number {
 }
 
 function hasActiveUpgradeOperation(system: System): boolean {
-  return !!system.activeOperation;
+  return !!system.activeOperation?.type.includes("upgrade") && !isPostUpgradeRecheck(system.activeOperation);
 }
 
 function isUpgradeAllEligible(system: System, locallyUpgrading: boolean): boolean {
@@ -93,6 +93,10 @@ export function canToggleUpgradePreset(
   upgradeEditMode: boolean,
 ): boolean {
   return upgradeEditMode || system.updateCount > 0;
+}
+
+export function isUpgradeAllSubmitDisabled(selectedSystemsCount: number, busy: boolean): boolean {
+  return selectedSystemsCount === 0 || busy;
 }
 
 function parseManagerList(value: unknown): string[] {
@@ -384,6 +388,11 @@ export default function Dashboard() {
   const hasUpgradeInProgress =
     upgradingCount > 0 ||
     (systems?.some((s) => isUpgrading(s.id) || hasActiveUpgradeOperation(s)) ?? false);
+  const hasRefreshInProgress =
+    refreshCache.isPending ||
+    (systems?.some((s) => s.activeOperation?.type === "check") ?? false);
+  const disableRefreshAll = refreshCache.isPending || hasActiveOps;
+  const disableUpgradeSubmit = refreshCache.isPending || hasActiveOps;
   const systemsWithUpdates = useMemo(
     () => systems?.filter((s) => isUpgradeAllEligible(s, isUpgrading(s.id))) ?? [],
     [systems, isUpgrading]
@@ -1079,14 +1088,20 @@ export default function Dashboard() {
         <div className="flex items-center gap-2 flex-wrap justify-end">
           <button
             onClick={handleRefresh}
-            disabled={refreshCache.isPending || hasUpgradeInProgress}
+            disabled={disableRefreshAll}
             className="px-3 py-1.5 text-sm rounded-lg border border-border hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors disabled:opacity-50 whitespace-nowrap"
           >
-            {refreshCache.isPending ? <span className="spinner spinner-sm" /> : "Refresh All"}
+            {hasRefreshInProgress ? (
+              <span className="flex items-center gap-1.5">
+                <span className="spinner spinner-sm" />
+                Refreshing...
+              </span>
+            ) : (
+              "Refresh All"
+            )}
           </button>
           <button
             onClick={openUpgradeConfirm}
-            disabled={hasUpgradeInProgress}
             className="px-3 py-1.5 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors disabled:opacity-50 whitespace-nowrap"
           >
             {hasUpgradeInProgress ? (
@@ -1351,7 +1366,7 @@ export default function Dashboard() {
           </button>
           <button
             onClick={handleUpgradeAll}
-            disabled={selectedSystems.length === 0 || hasUpgradeInProgress}
+            disabled={isUpgradeAllSubmitDisabled(selectedSystems.length, disableUpgradeSubmit)}
             className="w-full px-4 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors disabled:opacity-50 sm:w-auto"
           >
             Upgrade All

--- a/client/pages/SystemDetail.tsx
+++ b/client/pages/SystemDetail.tsx
@@ -5,12 +5,16 @@ import { AgoLabel } from "../components/AgoLabel";
 import { Badge } from "../components/Badge";
 import { CopyableCodeBlock } from "../components/CopyableCodeBlock";
 import { ConfirmDialog } from "../components/ConfirmDialog";
+import { Modal } from "../components/Modal";
 import { TerminalText } from "../components/TerminalText";
+import { SudoersSetupPanel } from "../components/systems/SudoersSetupPanel";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   useSystem,
+  useSudoersPreview,
   useRebootSystem,
   useDismissNeedsReboot,
+  useDismissRootUserBanner,
   useSolvePackageIssue,
   useDismissPackageIssue,
 } from "../lib/systems";
@@ -479,6 +483,67 @@ export function PackageManagerIssueBanner({
         );
       })}
     </div>
+  );
+}
+
+export function RootUserInfoBanner({
+  systemName,
+  busy,
+  onOpenSudoers,
+  onDismiss,
+}: {
+  systemName: string;
+  busy?: boolean;
+  onOpenSudoers: () => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-3 px-4 py-3 mb-6 rounded-xl border border-blue-300 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 text-blue-800 dark:text-blue-200 text-sm sm:flex-row sm:items-center">
+      <svg className="w-5 h-5 shrink-0 mt-0.5 sm:mt-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <div className="min-w-0 flex-1">
+        <p className="font-medium">Least-privilege user recommended</p>
+        <p className="mt-1 text-blue-700 dark:text-blue-300">
+          {systemName} connects as <code className="font-mono">root</code>. A dedicated non-root SSH user with limited sudoers rules is recommended for routine update work.
+        </p>
+      </div>
+      <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+        <button
+          type="button"
+          onClick={onOpenSudoers}
+          className="px-3 py-1 text-xs font-medium rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors whitespace-nowrap"
+        >
+          Sudoers Setup
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          disabled={busy}
+          className="px-3 py-1 text-xs font-medium rounded-lg border border-blue-300 dark:border-blue-700 bg-white/70 dark:bg-slate-900/30 text-blue-700 dark:text-blue-300 hover:bg-white dark:hover:bg-slate-900/50 transition-colors disabled:opacity-50 whitespace-nowrap"
+        >
+          {busy ? (
+            <span className="flex items-center gap-1.5">
+              <span className="spinner spinner-sm" />
+              Dismissing...
+            </span>
+          ) : "Dismiss"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function shouldShowRootUserInfoBanner(system: Pick<
+  import("../lib/systems").System,
+  "username" | "hostKeyVerificationEnabled" | "rootUserBannerDismissed" | "rootUserBannerDismissedHostKeyFingerprintSha256" | "trustedHostKeyFingerprintSha256"
+>): boolean {
+  if (system.username !== "root") return false;
+  if (system.hostKeyVerificationEnabled !== 0 && !system.trustedHostKeyFingerprintSha256) return false;
+  if (system.rootUserBannerDismissed !== 1) return true;
+  return (
+    (system.rootUserBannerDismissedHostKeyFingerprintSha256 ?? null) !==
+    (system.trustedHostKeyFingerprintSha256 ?? null)
   );
 }
 
@@ -1576,6 +1641,7 @@ export default function SystemDetail() {
   const cancelOperation = useCancelOperation();
   const rebootSystem = useRebootSystem();
   const dismissNeedsReboot = useDismissNeedsReboot();
+  const dismissRootUserBanner = useDismissRootUserBanner();
   const solvePackageIssue = useSolvePackageIssue();
   const dismissPackageIssue = useDismissPackageIssue();
   const [showUpgradeConfirm, setShowUpgradeConfirm] = useState(false);
@@ -1585,6 +1651,7 @@ export default function SystemDetail() {
   const [showRebootConfirm, setShowRebootConfirm] = useState(false);
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
   const [showDismissNeedsRebootConfirm, setShowDismissNeedsRebootConfirm] = useState(false);
+  const [showSudoersModal, setShowSudoersModal] = useState(false);
   const [pendingSolveIssue, setPendingSolveIssue] = useState<PackageManagerIssue | null>(null);
   const [pendingDismissIssue, setPendingDismissIssue] = useState<PackageManagerIssue | null>(null);
   const [pendingHideUpdate, setPendingHideUpdate] = useState<CachedUpdate | null>(null);
@@ -1593,6 +1660,7 @@ export default function SystemDetail() {
   const dropdownRef = useRef<HTMLDivElement>(null);
   const updatesSignatureRef = useRef<string | null>(null);
   const commandOutput = useCommandOutput(systemId);
+  const sudoersPreview = useSudoersPreview(systemId, { enabled: showSudoersModal });
   const qc = useQueryClient();
   const wasCommandActiveRef = useRef(false);
 
@@ -1650,6 +1718,7 @@ export default function SystemDetail() {
   const rebooting = rebootSystem.isPending || activeOp?.type === "reboot";
   const repairingPackageIssue = solvePackageIssue.isPending || activeOp?.type === "package_manager_repair";
   const dismissingNeedsReboot = dismissNeedsReboot.isPending;
+  const dismissingRootUserBanner = dismissRootUserBanner.isPending;
   const dismissingPackageIssue = dismissPackageIssue.isPending;
   const operationCancellable = !!activeOp && !activeOp.cancelRequested && !cancelOperation.isPending;
   const updatesSignature = data?.updates
@@ -1710,6 +1779,7 @@ export default function SystemDetail() {
   const showUpgradeDropdownActions = system.supportsFullUpgrade || hasAutoremoveAction;
   const upgradeActionsBusy = upgrading || autoremoving || checking || rebooting || repairingPackageIssue;
   const autoremoveConfirmMessage = getAutoremoveConfirmMessage(system.name, autoremoveSupport);
+  const showRootUserBanner = shouldShowRootUserInfoBanner(system);
 
   const handleCheck = () => {
     commandOutput.clear();
@@ -1805,6 +1875,13 @@ export default function SystemDetail() {
     setShowDismissNeedsRebootConfirm(false);
     dismissNeedsReboot.mutate(systemId, {
       onSuccess: () => addToast("Reboot warning dismissed", "success"),
+      onError: (err) => addToast(err.message, "danger"),
+    });
+  };
+
+  const handleDismissRootUserBanner = () => {
+    dismissRootUserBanner.mutate(systemId, {
+      onSuccess: () => addToast("Root user notice dismissed", "success"),
       onError: (err) => addToast(err.message, "danger"),
     });
   };
@@ -2088,6 +2165,15 @@ export default function SystemDetail() {
         />
       </div>
 
+      {showRootUserBanner && (
+        <RootUserInfoBanner
+          systemName={system.name}
+          busy={dismissingRootUserBanner}
+          onOpenSudoers={() => setShowSudoersModal(true)}
+          onDismiss={handleDismissRootUserBanner}
+        />
+      )}
+
       <PackageManagerIssueBanner
         issues={visiblePackageIssues}
         busy={upgrading || autoremoving || checking || rebooting || repairingPackageIssue}
@@ -2306,6 +2392,24 @@ export default function SystemDetail() {
         confirmLabel="Hide Update"
         loading={hideUpdate.isPending}
       />
+
+      <Modal
+        open={showSudoersModal}
+        onClose={() => setShowSudoersModal(false)}
+        title={`Sudoers Setup for ${system.name}`}
+      >
+        {sudoersPreview.isLoading ? (
+          <div className="flex justify-center py-10">
+            <span className="spinner !w-6 !h-6 text-blue-500" />
+          </div>
+        ) : sudoersPreview.data ? (
+          <SudoersSetupPanel preview={sudoersPreview.data} />
+        ) : (
+          <div className="text-sm text-slate-500 dark:text-slate-400">
+            Unable to load sudoers setup for this system right now.
+          </div>
+        )}
+      </Modal>
 
     </Layout>
   );

--- a/client/pages/SystemDetail.tsx
+++ b/client/pages/SystemDetail.tsx
@@ -389,43 +389,214 @@ export function getVisiblePackageIssuesForCurrentCheck(
   return isSudoCredentialFailure(lastCheck) ? [] : packageIssues;
 }
 
-function UpdateCheckNotice({
+type CheckOperationNoticeState = Extract<UpdatesPanelState, { kind: "check_failed" | "check_warning" }>;
+
+type OperationNoticeState = CheckOperationNoticeState | {
+  kind: "operation_failed" | "operation_warning";
+  action: string;
+  title: string;
+  message: string;
+  error: string | null;
+};
+
+function isCheckOperationNoticeState(state: OperationNoticeState): state is CheckOperationNoticeState {
+  return state.kind === "check_failed" || state.kind === "check_warning";
+}
+
+function getCheckOperationNoticeState(state: UpdatesPanelState | null): CheckOperationNoticeState | null {
+  if (!state) return null;
+  return state.kind === "check_failed" || state.kind === "check_warning" ? state : null;
+}
+
+function getHistoryEntryError(entry: HistoryEntry): string | null {
+  if (entry.error?.trim()) return entry.error;
+
+  const stepErrors = Array.from(new Set(
+    (entry.steps ?? [])
+      .map((step) => step.error?.trim())
+      .filter((error): error is string => !!error)
+  ));
+
+  return stepErrors.length > 0 ? stepErrors.join("\n\n") : null;
+}
+
+function getOperationNoticeCopy(
+  action: string,
+  status: "failed" | "warning",
+): Pick<OperationNoticeState, "title" | "message"> {
+  if (action === "check") {
+    return status === "failed"
+      ? {
+          title: "Update check failed",
+          message: "The latest update check did not complete, so the package list may be unavailable.",
+        }
+      : {
+          title: "Update check completed with warnings",
+          message: "One or more package manager checks failed, so this result may be incomplete.",
+        };
+  }
+
+  const copies: Record<string, Record<"failed" | "warning", Pick<OperationNoticeState, "title" | "message">>> = {
+    autoremove: {
+      failed: {
+        title: "Autoremove failed",
+        message: "The latest autoremove operation did not complete.",
+      },
+      warning: {
+        title: "Autoremove completed with warnings",
+        message: "The latest autoremove operation completed with warnings.",
+      },
+    },
+    upgrade_all: {
+      failed: {
+        title: "Upgrade failed",
+        message: "The latest upgrade operation did not complete.",
+      },
+      warning: {
+        title: "Upgrade completed with warnings",
+        message: "The latest upgrade operation completed with warnings.",
+      },
+    },
+    full_upgrade_all: {
+      failed: {
+        title: "Full upgrade failed",
+        message: "The latest full upgrade operation did not complete.",
+      },
+      warning: {
+        title: "Full upgrade completed with warnings",
+        message: "The latest full upgrade operation completed with warnings.",
+      },
+    },
+    upgrade_package: {
+      failed: {
+        title: "Selected upgrade failed",
+        message: "The selected package upgrade did not complete.",
+      },
+      warning: {
+        title: "Selected upgrade completed with warnings",
+        message: "The selected package upgrade completed with warnings.",
+      },
+    },
+    reboot: {
+      failed: {
+        title: "Reboot failed",
+        message: "The reboot operation did not complete.",
+      },
+      warning: {
+        title: "Reboot completed with warnings",
+        message: "The reboot operation completed with warnings.",
+      },
+    },
+    package_manager_repair: {
+      failed: {
+        title: "Package manager repair failed",
+        message: "The package manager repair operation did not complete.",
+      },
+      warning: {
+        title: "Package manager repair completed with warnings",
+        message: "The package manager repair operation completed with warnings.",
+      },
+    },
+  };
+
+  return copies[action]?.[status] ?? (
+    status === "failed"
+      ? {
+          title: "Operation failed",
+          message: "The latest operation did not complete.",
+        }
+      : {
+          title: "Operation completed with warnings",
+          message: "The latest operation completed with warnings.",
+        }
+  );
+}
+
+export function getOperationNoticeState(
+  latestHistoryEntry: HistoryEntry | null | undefined,
+  updatesCount: number,
+): OperationNoticeState | null {
+  if (!latestHistoryEntry) return null;
+  if (latestHistoryEntry.status !== "failed" && latestHistoryEntry.status !== "warning") return null;
+
+  const error = getHistoryEntryError(latestHistoryEntry);
+  if (!error) return null;
+
+  if (latestHistoryEntry.action === "check") {
+    if (latestHistoryEntry.status === "failed") {
+      return {
+        kind: "check_failed",
+        title: "Update check failed",
+        message: "The latest update check did not complete, so the package list may be unavailable.",
+        error,
+      };
+    }
+
+    const checkedUpdatesCount = latestHistoryEntry.packageCount ?? updatesCount;
+    return {
+      kind: "check_warning",
+      title: "Update check completed with warnings",
+      message: checkedUpdatesCount > 0
+        ? "Showing the updates that were found before one or more package manager checks failed."
+        : "One or more package manager checks failed, so this result may be incomplete.",
+      error,
+    };
+  }
+
+  return {
+    kind: latestHistoryEntry.status === "failed" ? "operation_failed" : "operation_warning",
+    action: latestHistoryEntry.action,
+    ...getOperationNoticeCopy(latestHistoryEntry.action, latestHistoryEntry.status),
+    error,
+  };
+}
+
+export function OperationNoticeBanner({
   state,
 }: {
-  state: UpdatesPanelState | null;
+  state: OperationNoticeState | null;
 }) {
   if (!state) return null;
-  if (state.kind !== "check_failed" && state.kind !== "check_warning") return null;
 
-  const tone = state.kind === "check_failed"
+  const isFailed = state.kind === "check_failed" || state.kind === "operation_failed";
+  const tone = isFailed
     ? {
         wrapper: "border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/20",
         title: "text-red-700 dark:text-red-300",
         body: "text-red-600 dark:text-red-400",
         code: "bg-red-100 dark:bg-red-950/40 text-red-700 dark:text-red-300",
+        icon: "text-red-500 dark:text-red-300",
       }
     : {
         wrapper: "border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20",
         title: "text-amber-700 dark:text-amber-300",
         body: "text-amber-700 dark:text-amber-400",
         code: "bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300",
+        icon: "text-amber-500 dark:text-amber-300",
       };
 
   return (
-    <div className={`mx-4 mt-4 mb-4 rounded-xl border px-4 py-3 ${tone.wrapper}`}>
-      <p className={`text-sm font-medium ${tone.title}`}>{state.title}</p>
-      <p className={`mt-1 text-sm ${tone.body}`}>{state.message}</p>
-      {state.error && (
-        <div className="mt-3">
-          <CopyableCodeBlock
-            text={state.error}
-            className={`overflow-x-auto rounded-lg px-3 py-2 text-xs whitespace-pre-wrap ${tone.code}`}
-            successMessage="Copied check output"
-          >
-            {state.error}
-          </CopyableCodeBlock>
+    <div className={`mb-6 rounded-xl border px-4 py-3 ${tone.wrapper}`}>
+      <div className="flex items-start gap-3">
+        <svg className={`mt-0.5 h-5 w-5 shrink-0 ${tone.icon}`} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+        </svg>
+        <div className="min-w-0 flex-1">
+          <p className={`text-sm font-medium ${tone.title}`}>{state.title}</p>
+          <p className={`mt-1 text-sm ${tone.body}`}>{state.message}</p>
+          {state.error && (
+            <div className="mt-3">
+              <CopyableCodeBlock
+                text={state.error}
+                className={`overflow-x-auto rounded-lg px-3 py-2 text-xs whitespace-pre-wrap ${tone.code}`}
+                successMessage="Copied check output"
+              >
+                {state.error}
+              </CopyableCodeBlock>
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 }
@@ -1798,8 +1969,17 @@ export default function SystemDetail() {
   const packageSelectionState = getPackageSelectionState(selectedPackageNames, updates, selectionBusy);
   const selectedVisiblePackageNames = packageSelectionState.selectedPackageNames;
   const updatesPanelState = getUpdatesPanelState(system, updates.length);
-  const dedupedUpdatesPanelState = dedupePackageIssueUpdateNotice(updatesPanelState, visiblePackageIssues);
-  const displayedUpdatesPanelState = omitHostKeyVerificationErrorFromUpdatesPanelState(dedupedUpdatesPanelState);
+  const latestOperationNoticeState: OperationNoticeState | null = history.length > 0
+    ? getOperationNoticeState(history[0], updates.length)
+    : getCheckOperationNoticeState(updatesPanelState);
+  const dedupedOperationNoticeState: OperationNoticeState | null =
+    latestOperationNoticeState && isCheckOperationNoticeState(latestOperationNoticeState)
+      ? getCheckOperationNoticeState(dedupePackageIssueUpdateNotice(latestOperationNoticeState, visiblePackageIssues))
+      : latestOperationNoticeState;
+  const displayedOperationNoticeState: OperationNoticeState | null =
+    dedupedOperationNoticeState && isCheckOperationNoticeState(dedupedOperationNoticeState)
+      ? getCheckOperationNoticeState(omitHostKeyVerificationErrorFromUpdatesPanelState(dedupedOperationNoticeState))
+      : dedupedOperationNoticeState;
   const showHostKeyVerificationBanner = hasHostKeyVerificationError(system.lastCheck);
   const updateState = deriveSystemUpdateState(system, { upgrading, checking: checking || repairingPackageIssue });
   const dotColor = updateState === "check_failed" || updateState === "unreachable"
@@ -2248,6 +2428,8 @@ export default function SystemDetail() {
         onDismiss={setPendingDismissIssue}
       />
 
+      <OperationNoticeBanner state={displayedOperationNoticeState} />
+
       {/* Reboot required warning */}
       {system.needsReboot === 1 && (
         <div className="flex items-center gap-2 px-4 py-3 mb-6 rounded-xl border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 text-sm">
@@ -2302,21 +2484,14 @@ export default function SystemDetail() {
             <AgoLabel timestamp={system.cacheTimestamp} stale={system.isStale} />
           )}
         </div>
-        <UpdateCheckNotice state={displayedUpdatesPanelState} />
-        {updates.length > 0 ? (
-          <UpdatesTable
-            updates={updates}
-            onTogglePackage={handleTogglePackageSelection}
-            selectedPackageNames={selectedVisiblePackageNames}
-            selectionDisabled={packageSelectionState.selectionDisabled}
-            hideBusy={hideUpdate.isPending}
-            onHide={setPendingHideUpdate}
-          />
-        ) : updatesPanelState.kind === "up_to_date" ? (
-          <div className="text-center py-8 text-sm text-slate-500 dark:text-slate-400">
-            No updates available
-          </div>
-        ) : null}
+        <UpdatesTable
+          updates={updates}
+          onTogglePackage={handleTogglePackageSelection}
+          selectedPackageNames={selectedVisiblePackageNames}
+          selectionDisabled={packageSelectionState.selectionDisabled}
+          hideBusy={hideUpdate.isPending}
+          onHide={setPendingHideUpdate}
+        />
       </div>
 
       <InstalledPackagesSection

--- a/client/pages/SystemDetail.tsx
+++ b/client/pages/SystemDetail.tsx
@@ -34,7 +34,16 @@ import type {
   LastCheckSummary,
   PackageManagerIssue,
 } from "../lib/systems";
-import { deriveSystemUpdateState, getUpdatesPanelState, isPostAutoremoveRecheck, isPostUpgradeRecheck, shouldClearLocalUpgrade, type UpdatesPanelState } from "../lib/system-status";
+import {
+  deriveSystemUpdateState,
+  getUpdatesPanelState,
+  hasHostKeyVerificationError,
+  isPostAutoremoveRecheck,
+  isPostUpgradeRecheck,
+  omitHostKeyVerificationErrorFromUpdatesPanelState,
+  shouldClearLocalUpgrade,
+  type UpdatesPanelState,
+} from "../lib/system-status";
 import { getUpgradeBehaviorNotes } from "../lib/package-manager-configs";
 import { getHostKeyStatusText } from "../lib/host-key-status";
 import { formatDurationBetween } from "../lib/time";
@@ -530,6 +539,35 @@ export function RootUserInfoBanner({
           ) : "Dismiss"}
         </button>
       </div>
+    </div>
+  );
+}
+
+export function HostKeyVerificationBanner({
+  systemName,
+  onOpenConfiguration,
+}: {
+  systemName: string;
+  onOpenConfiguration: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-3 px-4 py-3 mb-6 rounded-xl border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 text-sm sm:flex-row sm:items-center">
+      <svg className="w-5 h-5 shrink-0 mt-0.5 sm:mt-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 11c.943 0 1.809.325 2.493.869M17 8.5V7a5 5 0 00-10 0v1.5M5 11h14v9H5v-9z" />
+      </svg>
+      <div className="min-w-0 flex-1">
+        <p className="font-medium">SSH host-key approval required</p>
+        <p className="mt-1 text-red-600 dark:text-red-400">
+          {systemName} needs its SSH host key reviewed before update checks can run.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onOpenConfiguration}
+        className="px-3 py-1 text-xs font-medium rounded-lg bg-red-600 hover:bg-red-700 text-white transition-colors whitespace-nowrap shrink-0"
+      >
+        Open Configuration
+      </button>
     </div>
   );
 }
@@ -1756,6 +1794,8 @@ export default function SystemDetail() {
   const selectedVisiblePackageNames = packageSelectionState.selectedPackageNames;
   const updatesPanelState = getUpdatesPanelState(system, updates.length);
   const dedupedUpdatesPanelState = dedupePackageIssueUpdateNotice(updatesPanelState, visiblePackageIssues);
+  const displayedUpdatesPanelState = omitHostKeyVerificationErrorFromUpdatesPanelState(dedupedUpdatesPanelState);
+  const showHostKeyVerificationBanner = hasHostKeyVerificationError(system.lastCheck);
   const updateState = deriveSystemUpdateState(system, { upgrading, checking: checking || repairingPackageIssue });
   const dotColor = updateState === "check_failed" || updateState === "unreachable"
     ? "bg-red-500"
@@ -2174,6 +2214,13 @@ export default function SystemDetail() {
         />
       )}
 
+      {showHostKeyVerificationBanner && (
+        <HostKeyVerificationBanner
+          systemName={system.name}
+          onOpenConfiguration={() => navigate("/systems", { state: { editSystemId: system.id } })}
+        />
+      )}
+
       <PackageManagerIssueBanner
         issues={visiblePackageIssues}
         busy={upgrading || autoremoving || checking || rebooting || repairingPackageIssue}
@@ -2237,7 +2284,7 @@ export default function SystemDetail() {
             <AgoLabel timestamp={system.cacheTimestamp} stale={system.isStale} />
           )}
         </div>
-        <UpdateCheckNotice state={dedupedUpdatesPanelState} />
+        <UpdateCheckNotice state={displayedUpdatesPanelState} />
         {updates.length > 0 ? (
           <UpdatesTable
             updates={updates}

--- a/client/pages/SystemDetail.tsx
+++ b/client/pages/SystemDetail.tsx
@@ -626,7 +626,7 @@ export function PackageManagerIssueBanner({
         return (
           <div
             key={issue.id}
-            className="flex items-center gap-2 px-4 py-3 rounded-xl border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 text-sm"
+            className="flex items-center gap-2 px-4 py-3 rounded-xl border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 text-sm"
           >
             <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v4m0 4h.01M4.93 19h14.14c1.54 0 2.5-1.67 1.73-3L13.73 4c-.77-1.33-2.69-1.33-3.46 0L3.2 16c-.77 1.33.19 3 1.73 3z" />
@@ -634,14 +634,14 @@ export function PackageManagerIssueBanner({
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2 flex-wrap">
                 <span className="font-medium">{issue.title}</span>
-                <Badge variant="danger" small>{issue.pkgManager}</Badge>
+                <Badge variant="warning" small>{issue.pkgManager}</Badge>
               </div>
-              <p className="text-red-600 dark:text-red-400">{issue.message}</p>
+              <p className="text-amber-700 dark:text-amber-400">{issue.message}</p>
             </div>
             <button
               onClick={() => onSolve(issue)}
               disabled={busy || solving || dismissing}
-              className="px-3 py-1 text-xs font-medium rounded-lg bg-red-600 hover:bg-red-700 text-white transition-colors disabled:opacity-50 whitespace-nowrap shrink-0"
+              className="px-3 py-1 text-xs font-medium rounded-lg bg-amber-600 hover:bg-amber-700 text-white transition-colors disabled:opacity-50 whitespace-nowrap shrink-0"
             >
               {solving ? (
                 <span className="flex items-center gap-1.5">
@@ -653,7 +653,7 @@ export function PackageManagerIssueBanner({
             <button
               onClick={() => onDismiss(issue)}
               disabled={busy || solving || dismissing}
-              className="px-3 py-1 text-xs font-medium rounded-lg border border-red-300 dark:border-red-800 bg-white/70 dark:bg-slate-900/30 text-red-700 dark:text-red-300 hover:bg-white dark:hover:bg-slate-900/50 transition-colors disabled:opacity-50 whitespace-nowrap shrink-0"
+              className="px-3 py-1 text-xs font-medium rounded-lg border border-amber-300 dark:border-amber-700 bg-white/70 dark:bg-slate-900/30 text-amber-700 dark:text-amber-400 hover:bg-white dark:hover:bg-slate-900/50 transition-colors disabled:opacity-50 whitespace-nowrap shrink-0"
             >
               {dismissing ? (
                 <span className="flex items-center gap-1.5">
@@ -725,20 +725,20 @@ export function HostKeyVerificationBanner({
   onOpenConfiguration: () => void;
 }) {
   return (
-    <div className="flex flex-col gap-3 px-4 py-3 mb-6 rounded-xl border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 text-sm sm:flex-row sm:items-center">
+    <div className="flex flex-col gap-3 px-4 py-3 mb-6 rounded-xl border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 text-sm sm:flex-row sm:items-center">
       <svg className="w-5 h-5 shrink-0 mt-0.5 sm:mt-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 11c.943 0 1.809.325 2.493.869M17 8.5V7a5 5 0 00-10 0v1.5M5 11h14v9H5v-9z" />
       </svg>
       <div className="min-w-0 flex-1">
         <p className="font-medium">SSH host-key approval required</p>
-        <p className="mt-1 text-red-600 dark:text-red-400">
+        <p className="mt-1 text-amber-700 dark:text-amber-400">
           {systemName} needs its SSH host key reviewed before update checks can run.
         </p>
       </div>
       <button
         type="button"
         onClick={onOpenConfiguration}
-        className="px-3 py-1 text-xs font-medium rounded-lg bg-red-600 hover:bg-red-700 text-white transition-colors whitespace-nowrap shrink-0"
+        className="px-3 py-1 text-xs font-medium rounded-lg bg-amber-600 hover:bg-amber-700 text-white transition-colors whitespace-nowrap shrink-0"
       >
         Open Configuration
       </button>

--- a/client/pages/SystemDetail.tsx
+++ b/client/pages/SystemDetail.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect, useLayoutEffect, useMemo } from "react";
+import { useState, useCallback, useRef, useEffect, useLayoutEffect, useMemo, type ComponentProps } from "react";
 import { useParams, useNavigate } from "react-router";
 import { Layout } from "../components/Layout";
 import { AgoLabel } from "../components/AgoLabel";
@@ -7,11 +7,13 @@ import { CopyableCodeBlock } from "../components/CopyableCodeBlock";
 import { ConfirmDialog } from "../components/ConfirmDialog";
 import { Modal } from "../components/Modal";
 import { TerminalText } from "../components/TerminalText";
+import { SystemForm } from "../components/systems/SystemForm";
 import { SudoersSetupPanel } from "../components/systems/SudoersSetupPanel";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   useSystem,
   useSudoersPreview,
+  useUpdateSystem,
   useRebootSystem,
   useDismissNeedsReboot,
   useDismissRootUserBanner,
@@ -51,6 +53,7 @@ import { highlightShell } from "../lib/shell-highlight";
 import { formatScriptCommand } from "../lib/scripts";
 
 const useBrowserLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
+type SystemFormSubmitData = Parameters<ComponentProps<typeof SystemForm>["onSubmit"]>[0];
 
 function InfoCard({ title, items }: { title: string; items: { label: string; value: string | null }[] }) {
   return (
@@ -1682,6 +1685,7 @@ export default function SystemDetail() {
   const dismissRootUserBanner = useDismissRootUserBanner();
   const solvePackageIssue = useSolvePackageIssue();
   const dismissPackageIssue = useDismissPackageIssue();
+  const updateSystem = useUpdateSystem();
   const [showUpgradeConfirm, setShowUpgradeConfirm] = useState(false);
   const [showAutoremoveConfirm, setShowAutoremoveConfirm] = useState(false);
   const [showUpgradeSelectedConfirm, setShowUpgradeSelectedConfirm] = useState(false);
@@ -1689,6 +1693,7 @@ export default function SystemDetail() {
   const [showRebootConfirm, setShowRebootConfirm] = useState(false);
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
   const [showDismissNeedsRebootConfirm, setShowDismissNeedsRebootConfirm] = useState(false);
+  const [showConfigurationModal, setShowConfigurationModal] = useState(false);
   const [showSudoersModal, setShowSudoersModal] = useState(false);
   const [pendingSolveIssue, setPendingSolveIssue] = useState<PackageManagerIssue | null>(null);
   const [pendingDismissIssue, setPendingDismissIssue] = useState<PackageManagerIssue | null>(null);
@@ -1820,6 +1825,19 @@ export default function SystemDetail() {
   const upgradeActionsBusy = upgrading || autoremoving || checking || rebooting || repairingPackageIssue;
   const autoremoveConfirmMessage = getAutoremoveConfirmMessage(system.name, autoremoveSupport);
   const showRootUserBanner = shouldShowRootUserInfoBanner(system);
+
+  const handleUpdateConfiguration = (formData: SystemFormSubmitData) => {
+    updateSystem.mutate(
+      { id: system.id, ...formData },
+      {
+        onSuccess: () => {
+          setShowConfigurationModal(false);
+          addToast("System updated successfully", "success");
+        },
+        onError: (err) => addToast(err.message, "danger"),
+      },
+    );
+  };
 
   const handleCheck = () => {
     commandOutput.clear();
@@ -2217,7 +2235,7 @@ export default function SystemDetail() {
       {showHostKeyVerificationBanner && (
         <HostKeyVerificationBanner
           systemName={system.name}
-          onOpenConfiguration={() => navigate("/systems", { state: { editSystemId: system.id } })}
+          onOpenConfiguration={() => setShowConfigurationModal(true)}
         />
       )}
 
@@ -2439,6 +2457,39 @@ export default function SystemDetail() {
         confirmLabel="Hide Update"
         loading={hideUpdate.isPending}
       />
+
+      <Modal
+        open={showConfigurationModal}
+        onClose={() => setShowConfigurationModal(false)}
+        title="Edit System"
+        dismissible={!updateSystem.isPending}
+      >
+        <SystemForm
+          initial={{
+            name: system.name,
+            hostname: system.hostname,
+            port: system.port,
+            credentialId: system.credentialId ?? undefined,
+            proxyJumpSystemId: system.proxyJumpSystemId,
+            hostKeyVerificationEnabled:
+              system.hostKeyVerificationEnabled !== 0,
+            approvedHostKey: system.approvedHostKey,
+            trustedHostKeyFingerprintSha256:
+              system.trustedHostKeyFingerprintSha256,
+            detectedPkgManagers: system.detectedPkgManagers ?? undefined,
+            disabledPkgManagers: system.disabledPkgManagers ?? undefined,
+            pkgManagerConfigs: system.pkgManagerConfigs ?? undefined,
+            autoHideKeptBackUpdates: system.autoHideKeptBackUpdates,
+            hidden: system.hidden === 1,
+            hostKeyStatus: system.hostKeyStatus,
+            scriptOverrides: system.scriptOverrides,
+          }}
+          systemId={system.id}
+          onSubmit={handleUpdateConfiguration}
+          onCancel={() => setShowConfigurationModal(false)}
+          loading={updateSystem.isPending}
+        />
+      </Modal>
 
       <Modal
         open={showSudoersModal}

--- a/client/pages/SystemsList.tsx
+++ b/client/pages/SystemsList.tsx
@@ -16,10 +16,8 @@ import {
 } from "../lib/systems";
 import type { System } from "../lib/systems";
 import { useToast } from "../context/ToastContext";
-import { useUpgrade } from "../context/UpgradeContext";
 import { SystemForm } from "../components/systems/SystemForm";
 import { SudoersSetupPanel } from "../components/systems/SudoersSetupPanel";
-import { deriveSystemUpdateState, isPostAutoremoveRecheck, isPostUpgradeRecheck } from "../lib/system-status";
 import { getHostKeyStatusBadgeLabel } from "../lib/host-key-status";
 
 function moveSystem<T>(items: T[], fromIndex: number, toIndex: number): T[] {
@@ -47,7 +45,6 @@ export default function SystemsList() {
   const deleteSystem = useDeleteSystem();
   const reorderSystems = useReorderSystems();
   const { addToast } = useToast();
-  const { isUpgrading } = useUpgrade();
   const [showForm, setShowForm] = useState(false);
   const [duplicateSource, setDuplicateSource] = useState<System | null>(null);
   const [editSystem, setEditSystem] = useState<System | null>(
@@ -199,24 +196,16 @@ export default function SystemsList() {
                 <th className="px-2 sm:px-4 py-3 hidden sm:table-cell">Host</th>
                 <th className="px-2 sm:px-4 py-3 hidden md:table-cell">OS</th>
                 <th className="px-2 sm:px-4 py-3">Status</th>
-                <th className="px-2 sm:px-4 py-3">Updates</th>
                 <th className="px-2 sm:px-4 py-3 hidden lg:table-cell">Last Checked</th>
                 <th className="px-2 sm:px-4 py-3 text-right whitespace-nowrap">Actions</th>
               </tr>
             </thead>
             <tbody ref={tbodyRef}>
-              {orderedSystems.map((s) => {
-                const postUpgradeRechecking = isPostUpgradeRecheck(s.activeOperation);
-                const postAutoremoveRechecking = isPostAutoremoveRecheck(s.activeOperation);
-                const upgrading = !postUpgradeRechecking && (isUpgrading(s.id) || !!s.activeOperation?.type?.startsWith("upgrade"));
-                const checking = postUpgradeRechecking || postAutoremoveRechecking || s.activeOperation?.type === "check" || s.activeOperation?.type === "package_manager_repair";
-                const updateState = deriveSystemUpdateState(s, { upgrading, checking });
-
-                return (
-                  <tr
-                    key={s.id}
-                    className="border-b border-border last:border-0 hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors"
-                  >
+              {orderedSystems.map((s) => (
+                <tr
+                  key={s.id}
+                  className="border-b border-border last:border-0 hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors"
+                >
                   <td className="px-2 sm:px-4 py-3">
                     <div className="flex items-center gap-2 min-w-0">
                       <span
@@ -279,59 +268,6 @@ export default function SystemsList() {
                       )}
                     </div>
                   </td>
-                  <td className="px-2 sm:px-4 py-3">
-                    {updateState === "upgrading" ? (
-                      <Badge variant="info" small>
-                        <span className="flex items-center gap-1">
-                          <span className="spinner spinner-sm !w-2.5 !h-2.5" />
-                          Upgrading...
-                        </span>
-                      </Badge>
-                    ) : updateState === "maintaining" ? (
-                      <Badge variant="info" small>
-                        <span className="flex items-center gap-1">
-                          <span className="spinner spinner-sm !w-2.5 !h-2.5" />
-                          Maintaining...
-                        </span>
-                      </Badge>
-                    ) : updateState === "checking" ? (
-                      <Badge variant="info" small>
-                        <span className="flex items-center gap-1">
-                          <span className="spinner spinner-sm !w-2.5 !h-2.5" />
-                          Checking...
-                        </span>
-                      </Badge>
-                    ) : updateState === "check_failed" ? (
-                      <Badge variant="danger" small>Check failed</Badge>
-                    ) : updateState === "check_warning" ? (
-                      <div className="flex items-center gap-1.5 flex-wrap">
-                        <Badge variant="warning" small>Check warning</Badge>
-                        {s.updateCount > 0 && (
-                          <Badge variant="warning" small>{s.updateCount}</Badge>
-                        )}
-                        {s.securityCount > 0 && (
-                          <Badge variant="danger" small>{s.securityCount} security</Badge>
-                        )}
-                        {s.keptBackCount > 0 && (
-                          <Badge variant="muted" small>{s.keptBackCount} kept back</Badge>
-                        )}
-                      </div>
-                    ) : updateState === "updates_available" ? (
-                      <div className="flex items-center gap-1.5 flex-wrap">
-                        <Badge variant="warning" small>{s.updateCount}</Badge>
-                        {s.securityCount > 0 && (
-                          <Badge variant="danger" small>{s.securityCount} security</Badge>
-                        )}
-                        {s.keptBackCount > 0 && (
-                          <Badge variant="muted" small>{s.keptBackCount} kept back</Badge>
-                        )}
-                      </div>
-                    ) : updateState === "up_to_date" ? (
-                      <span className="text-green-600 text-xs">0</span>
-                    ) : (
-                      <span className="text-slate-400 text-xs">-</span>
-                    )}
-                  </td>
                   <td className="px-2 sm:px-4 py-3 hidden lg:table-cell">
                     {s.cacheTimestamp ? (
                       <AgoLabel timestamp={s.cacheTimestamp} stale={s.isStale} />
@@ -380,9 +316,8 @@ export default function SystemsList() {
                       </button>
                     </div>
                   </td>
-                  </tr>
-                );
-              })}
+                </tr>
+              ))}
             </tbody>
           </table>
         </div>

--- a/client/pages/SystemsList.tsx
+++ b/client/pages/SystemsList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Link } from "react-router";
+import { Link, useLocation, useNavigate } from "react-router";
 import Sortable from "sortablejs";
 import { Layout } from "../components/Layout";
 import { AgoLabel } from "../components/AgoLabel";
@@ -31,8 +31,17 @@ function moveSystem<T>(items: T[], fromIndex: number, toIndex: number): T[] {
   return nextItems;
 }
 
+export function getEditSystemIdFromRouteState(state: unknown): number | null {
+  if (!state || typeof state !== "object") return null;
+  const editSystemId = (state as { editSystemId?: unknown }).editSystemId;
+  return typeof editSystemId === "number" && Number.isFinite(editSystemId) ? editSystemId : null;
+}
+
 export default function SystemsList() {
   const { data: systems, isLoading, refetch } = useSystems();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const routeEditSystemId = getEditSystemIdFromRouteState(location.state);
   const createSystem = useCreateSystem();
   const updateSystem = useUpdateSystem();
   const deleteSystem = useDeleteSystem();
@@ -41,7 +50,9 @@ export default function SystemsList() {
   const { isUpgrading } = useUpgrade();
   const [showForm, setShowForm] = useState(false);
   const [duplicateSource, setDuplicateSource] = useState<System | null>(null);
-  const [editSystem, setEditSystem] = useState<System | null>(null);
+  const [editSystem, setEditSystem] = useState<System | null>(
+    () => systems?.find((system) => system.id === routeEditSystemId) ?? null,
+  );
   const [sudoersSystem, setSudoersSystem] = useState<System | null>(null);
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [orderedSystems, setOrderedSystems] = useState<System[]>(() => systems ?? []);
@@ -57,6 +68,16 @@ export default function SystemsList() {
     systemsRef.current = systems ?? [];
     setOrderedSystems(systems ?? []);
   }, [systems]);
+
+  useEffect(() => {
+    if (routeEditSystemId === null || !systems) return;
+
+    const targetSystem = systems.find((system) => system.id === routeEditSystemId) ?? null;
+    if (targetSystem) {
+      setEditSystem(targetSystem);
+    }
+    navigate(location.pathname, { replace: true, state: null });
+  }, [location.pathname, navigate, routeEditSystemId, systems]);
 
   useEffect(() => {
     orderedSystemsRef.current = orderedSystems;

--- a/docker/test-systems/Dockerfile.ubuntu-root
+++ b/docker/test-systems/Dockerfile.ubuntu-root
@@ -1,0 +1,51 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install all packages from an old archive snapshot (June 2025) so they appear
+# upgradable when the dashboard checks. Disables TLS peer verification so we
+# don't need ca-certificates (avoids mixing package versions across repos).
+# The current repos are restored afterward so update checks find newer versions.
+RUN mv /etc/apt/sources.list.d/ubuntu.sources /tmp/ubuntu.sources.bak && \
+    printf '%s\n' \
+      'deb [trusted=yes] http://snapshot.ubuntu.com/ubuntu/20250601T000000Z/ noble main universe' \
+      'deb [trusted=yes] http://snapshot.ubuntu.com/ubuntu/20250601T000000Z/ noble-updates main universe' \
+      'deb [trusted=yes] http://snapshot.ubuntu.com/ubuntu/20250601T000000Z/ noble-security main universe' \
+      > /etc/apt/sources.list && \
+    apt-get -o Acquire::Check-Valid-Until=false \
+            -o Acquire::https::Verify-Peer=false update && \
+    apt-get -o Acquire::https::Verify-Peer=false install -y \
+        openssh-server sudo \
+        curl wget vim-tiny openssl nano \
+        htop tree zip unzip jq && \
+    rm /etc/apt/sources.list && \
+    mv /tmp/ubuntu.sources.bak /etc/apt/sources.list.d/ubuntu.sources && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /run/sshd
+
+# Configure SSH
+RUN sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config && \
+    sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config && \
+    mkdir -p /etc/ssh/sshd_config.d && \
+    printf '%s\n' \
+      'PasswordAuthentication yes' \
+      'PermitRootLogin yes' \
+      > /etc/ssh/sshd_config.d/10-allow-password.conf
+
+# Create a root login for banner testing and a package-maintenance user with
+# unrestricted passwordless sudo.
+COPY sudoers/root-nopasswd /etc/sudoers.d/testuser
+RUN echo 'root:testpass' | chpasswd && \
+    useradd -m -s /bin/bash testuser && \
+    echo 'testuser:testpass' | chpasswd && \
+    chmod 440 /etc/sudoers.d/testuser && \
+    visudo -cf /etc/sudoers.d/testuser
+
+# Fail the build if unrestricted passwordless sudo is not available.
+RUN su - testuser -c "sudo -n true && sudo -n id -u | grep -qx 0"
+
+# Generate host keys
+RUN ssh-keygen -A
+
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]

--- a/docker/test-systems/docker-compose.yml
+++ b/docker/test-systems/docker-compose.yml
@@ -24,6 +24,7 @@
 #   Fedora  (DNF GPG key prompt fixture) → localhost:2013
 #   Fedora  (DNF EULA prompt fixture) → localhost:2014
 #   Debian  (APT interrupted dpkg fixture) → localhost:2015
+#   Ubuntu  (APT+root login/full sudo) → localhost:2016
 #
 # SSH examples:
 #   ssh testuser@localhost -p 2001   # Ubuntu  (APT)
@@ -41,6 +42,8 @@
 #   ssh testuser@localhost -p 2013   # Fedora  (DNF GPG key prompt fixture)
 #   ssh testuser@localhost -p 2014   # Fedora  (DNF EULA prompt fixture)
 #   ssh testuser@localhost -p 2015   # Debian  (APT interrupted dpkg fixture)
+#   ssh root@localhost -p 2016       # Ubuntu  (APT + root login)
+#   ssh testuser@localhost -p 2016   # Ubuntu  (APT + full sudo)
 #
 # Note: Flatpak needs --privileged for bubblewrap (used during install/update).
 # Snap needs systemd as PID 1 + --privileged for snapd to function.
@@ -202,4 +205,14 @@ services:
     hostname: apt-dpkg-interrupted-test
     ports:
       - "2015:22"
+    restart: unless-stopped
+
+  ubuntu-root:
+    build:
+      context: .
+      dockerfile: Dockerfile.ubuntu-root
+    container_name: ludash-test-ubuntu-root
+    hostname: ubuntu-root-test
+    ports:
+      - "2016:22"
     restart: unless-stopped

--- a/docker/test-systems/sudoers/root-nopasswd
+++ b/docker/test-systems/sudoers/root-nopasswd
@@ -1,0 +1,3 @@
+Defaults:testuser !requiretty
+
+testuser ALL=(ALL) NOPASSWD: ALL

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -165,6 +165,8 @@ export function initDatabase(dbPath: string): BetterSQLite3Database<typeof schem
     reboot_dismissed_boot_id TEXT,
     reboot_dismissed_uptime_seconds REAL,
     reboot_dismissed_at TEXT,
+    root_user_banner_dismissed INTEGER NOT NULL DEFAULT 0,
+    root_user_banner_dismissed_host_key_fingerprint_sha256 TEXT,
     system_info_updated_at TEXT,
     is_reachable INTEGER NOT NULL DEFAULT 0,
     last_seen_at TEXT,
@@ -588,7 +590,16 @@ export function initDatabase(dbPath: string): BetterSQLite3Database<typeof schem
   } catch {
     // Column already exists
   }
-
+  try {
+    _db.run(sql`ALTER TABLE systems ADD COLUMN root_user_banner_dismissed INTEGER NOT NULL DEFAULT 0`);
+  } catch {
+    // Column already exists
+  }
+  try {
+    _db.run(sql`ALTER TABLE systems ADD COLUMN root_user_banner_dismissed_host_key_fingerprint_sha256 TEXT`);
+  } catch {
+    // Column already exists
+  }
   // Migration: add notification schedule columns
   try {
     _db.run(sql`ALTER TABLE notifications ADD COLUMN schedule TEXT`);
@@ -1158,6 +1169,8 @@ function rebuildSystemsTable(
       reboot_dismissed_boot_id TEXT,
       reboot_dismissed_uptime_seconds REAL,
       reboot_dismissed_at TEXT,
+      root_user_banner_dismissed INTEGER NOT NULL DEFAULT 0,
+      root_user_banner_dismissed_host_key_fingerprint_sha256 TEXT,
       system_info_updated_at TEXT,
       is_reachable INTEGER NOT NULL DEFAULT 0,
       last_seen_at TEXT,
@@ -1209,6 +1222,8 @@ function rebuildSystemsTable(
     "reboot_dismissed_boot_id",
     "reboot_dismissed_uptime_seconds",
     "reboot_dismissed_at",
+    "root_user_banner_dismissed",
+    "root_user_banner_dismissed_host_key_fingerprint_sha256",
     "system_info_updated_at",
     "is_reachable",
     "last_seen_at",
@@ -1263,6 +1278,8 @@ function rebuildSystemsTable(
     "reboot_dismissed_boot_id",
     "reboot_dismissed_uptime_seconds",
     "reboot_dismissed_at",
+    "root_user_banner_dismissed",
+    "root_user_banner_dismissed_host_key_fingerprint_sha256",
     "system_info_updated_at",
     "is_reachable",
     "last_seen_at",

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -98,6 +98,10 @@ export const systems = sqliteTable(
     rebootDismissedBootId: text("reboot_dismissed_boot_id"),
     rebootDismissedUptimeSeconds: real("reboot_dismissed_uptime_seconds"),
     rebootDismissedAt: text("reboot_dismissed_at"),
+    rootUserBannerDismissed: integer("root_user_banner_dismissed")
+      .notNull()
+      .default(0),
+    rootUserBannerDismissedHostKeyFingerprintSha256: text("root_user_banner_dismissed_host_key_fingerprint_sha256"),
     excludeFromUpgradeAll: integer("exclude_from_upgrade_all")
       .notNull()
       .default(0),

--- a/server/routes/systems.ts
+++ b/server/routes/systems.ts
@@ -1063,6 +1063,16 @@ systems.post("/:id/dismiss-needs-reboot", async (c) => {
   return c.json({ status: "ok" });
 });
 
+systems.post("/:id/dismiss-root-user-banner", (c) => {
+  const id = parseId(c.req.param("id"));
+  if (!id) return c.json({ error: "Invalid system ID" }, 400);
+  const system = systemService.getSystem(id);
+  if (!system) return c.json({ error: "System not found" }, 404);
+
+  systemService.dismissRootUserBanner(id);
+  return c.json({ status: "ok" });
+});
+
 systems.post("/:id/revoke-host-key", (c) => {
   const id = parseId(c.req.param("id"));
   if (!id) return c.json({ error: "Invalid system ID" }, 400);

--- a/server/services/system-service.ts
+++ b/server/services/system-service.ts
@@ -64,6 +64,11 @@ export class RebootDismissalSnapshotRequiredError extends Error {
   }
 }
 
+function clearRootUserBannerDismissal(values: Record<string, unknown>): void {
+  values.rootUserBannerDismissed = 0;
+  values.rootUserBannerDismissedHostKeyFingerprintSha256 = null;
+}
+
 function normalizeStringList(value: string[] | string | null | undefined): string[] {
   const raw = Array.isArray(value)
     ? value
@@ -566,12 +571,14 @@ export function updateSystem(
     values.trustedHostKeyAlgorithm = null;
     values.trustedHostKeyFingerprintSha256 = null;
     values.hostKeyTrustedAt = null;
+    clearRootUserBannerDismissal(values);
   }
   if (data.hostKeyVerificationEnabled === false) {
     values.trustedHostKey = null;
     values.trustedHostKeyAlgorithm = null;
     values.trustedHostKeyFingerprintSha256 = null;
     values.hostKeyTrustedAt = null;
+    clearRootUserBannerDismissal(values);
   } else if (data.trustedHostKeyData) {
     values.trustedHostKey = data.trustedHostKeyData.rawKey;
     values.trustedHostKeyAlgorithm = data.trustedHostKeyData.algorithm;
@@ -623,6 +630,22 @@ export function dismissNeedsReboot(systemId: number): void {
       rebootDismissedUptimeSeconds: uptimeSeconds,
       rebootDismissedAt: now,
       updatedAt: now,
+    })
+    .where(eq(systems.id, systemId))
+    .run();
+}
+
+export function dismissRootUserBanner(systemId: number): void {
+  const db = getDb();
+  const existing = getSystem(systemId);
+  if (!existing) throw new Error("System not found");
+
+  db.update(systems)
+    .set({
+      rootUserBannerDismissed: 1,
+      rootUserBannerDismissedHostKeyFingerprintSha256:
+        existing.trustedHostKeyFingerprintSha256 ?? null,
+      updatedAt: new Date().toISOString().replace("T", " ").slice(0, 19),
     })
     .where(eq(systems.id, systemId))
     .run();
@@ -1079,6 +1102,8 @@ export function clearTrustedHostKey(systemId: number): void {
       trustedHostKeyAlgorithm: null,
       trustedHostKeyFingerprintSha256: null,
       hostKeyTrustedAt: null,
+      rootUserBannerDismissed: 0,
+      rootUserBannerDismissedHostKeyFingerprintSha256: null,
     })
     .where(eq(systems.id, systemId))
     .run();

--- a/tests/client/dashboard.test.tsx
+++ b/tests/client/dashboard.test.tsx
@@ -81,8 +81,23 @@ import Dashboard, {
   applyUpgradeSystemPlacements,
   canToggleUpgradePreset,
   getDashboardUpgradeToast,
+  isUpgradeAllSubmitDisabled,
   isUpgradePresetSelected,
 } from "../../client/pages/Dashboard";
+
+function getOpeningButtonTag(html: string, text: string): string {
+  const textIndex = html.indexOf(text);
+  expect(textIndex).toBeGreaterThan(-1);
+  const buttonIndex = html.lastIndexOf("<button", textIndex);
+  expect(buttonIndex).toBeGreaterThan(-1);
+  const buttonEnd = html.indexOf(">", buttonIndex);
+  expect(buttonEnd).toBeGreaterThan(-1);
+  return html.slice(buttonIndex, buttonEnd + 1);
+}
+
+function hasDisabledAttribute(tag: string): boolean {
+  return /\sdisabled(?:=|\s|>)/.test(tag);
+}
 
 describe("Dashboard", () => {
   beforeEach(() => {
@@ -157,7 +172,7 @@ describe("Dashboard", () => {
     expect(html).not.toContain("Upgrade All (7)");
   });
 
-  test("disables dashboard refresh and upgrade actions while the server reports an active upgrade", () => {
+  test("shows active upgrades without disabling the dashboard upgrade modal launcher", () => {
     mockUseDashboardSystems.mockReturnValue({
       data: [
         {
@@ -197,8 +212,75 @@ describe("Dashboard", () => {
     );
 
     expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Refresh All<\/button>/);
-    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>.*Upgrading\.\.\..*<\/button>/s);
+    expect(html).toContain("Upgrading...");
+    expect(hasDisabledAttribute(getOpeningButtonTag(html, "Upgrading..."))).toBe(false);
     expect(html).not.toContain(">Upgrade All</button>");
+  });
+
+  test("does not show the dashboard upgrade action as upgrading during refresh", () => {
+    mockUseRefreshCache.mockReturnValue({ mutate: vi.fn(), isPending: true });
+
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>,
+    );
+
+    expect(html).toContain("Refreshing...");
+    expect(hasDisabledAttribute(getOpeningButtonTag(html, "Refreshing..."))).toBe(true);
+    expect(hasDisabledAttribute(getOpeningButtonTag(html, "Upgrade All"))).toBe(false);
+    expect(html).not.toContain("Upgrading...");
+  });
+
+  test("does not show the dashboard upgrade action as upgrading during active system checks", () => {
+    mockUseDashboardSystems.mockReturnValue({
+      data: [
+        {
+          id: 1,
+          name: "Alpha",
+          hostname: "alpha.local",
+          port: 22,
+          osName: "Debian",
+          isReachable: 1,
+          updateCount: 7,
+          securityCount: 2,
+          keptBackCount: 0,
+          cacheAge: null,
+          cacheTimestamp: null,
+          isStale: false,
+          lastCheck: null,
+          activeOperation: {
+            type: "check",
+            startedAt: "2026-05-18 10:00:00",
+          },
+          excludeFromUpgradeAll: 0,
+          upgradeOrder: 1,
+          pkgManager: "apt",
+          detectedPkgManagers: ["apt"],
+          disabledPkgManagers: [],
+          pkgManagerConfigs: null,
+          supportsFullUpgrade: true,
+        },
+      ],
+      dataUpdatedAt: Date.now(),
+    });
+
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>,
+    );
+
+    expect(html).toContain("Refreshing...");
+    expect(hasDisabledAttribute(getOpeningButtonTag(html, "Refreshing..."))).toBe(true);
+    expect(hasDisabledAttribute(getOpeningButtonTag(html, "Upgrade All"))).toBe(false);
+    expect(html).not.toContain("Upgrading...");
+  });
+
+  test("disables the modal Upgrade All submit while dashboard work is running", () => {
+    expect(isUpgradeAllSubmitDisabled(1, true)).toBe(true);
+    expect(isUpgradeAllSubmitDisabled(1, false)).toBe(false);
+    expect(isUpgradeAllSubmitDisabled(0, false)).toBe(true);
   });
 
   test("treats recovered upgrade warnings as informational dashboard toasts", () => {

--- a/tests/client/system-detail-activity.test.ts
+++ b/tests/client/system-detail-activity.test.ts
@@ -13,6 +13,8 @@ import {
   isScrollNearBottom,
   matchesHistoryEntryToSession,
   PackageManagerIssueBanner,
+  RootUserInfoBanner,
+  shouldShowRootUserInfoBanner,
   toggleSelectedPackageName,
   resolveCurrentActivitySession,
   shouldShowAutoremoveAction,
@@ -47,6 +49,91 @@ describe("autoremove action", () => {
     expect(getAutoremoveConfirmMessage("Debian", support)).toContain("Will run for: apt, flatpak.");
     expect(getAutoremoveConfirmMessage("Debian", support)).toContain("configured: snap.");
     expect(shouldShowAutoremoveAction({ supportedManagers: [] })).toBe(false);
+  });
+});
+
+describe("RootUserInfoBanner", () => {
+  test("renders as an informational notice with sudoers and dismiss actions", () => {
+    const html = renderToStaticMarkup(createElement(RootUserInfoBanner, {
+      systemName: "Debian",
+      onOpenSudoers: () => {},
+      onDismiss: () => {},
+    }));
+
+    expect(html).toContain("Least-privilege user recommended");
+    expect(html).toContain("connects as");
+    expect(html).toContain("root");
+    expect(html).toContain("Sudoers Setup");
+    expect(html).toContain("Dismiss");
+    expect(html).toContain("bg-blue-50");
+    expect(html).not.toContain("bg-amber-50");
+    expect(html).not.toContain("bg-red-50");
+  });
+
+  test("reappears after a host key fingerprint change", () => {
+    expect(shouldShowRootUserInfoBanner({
+      username: "testuser",
+      hostKeyVerificationEnabled: 1,
+      rootUserBannerDismissed: 0,
+      rootUserBannerDismissedHostKeyFingerprintSha256: null,
+      trustedHostKeyFingerprintSha256: "SHA256:current",
+    })).toBe(false);
+
+    expect(shouldShowRootUserInfoBanner({
+      username: "root",
+      hostKeyVerificationEnabled: 1,
+      rootUserBannerDismissed: 0,
+      rootUserBannerDismissedHostKeyFingerprintSha256: null,
+      trustedHostKeyFingerprintSha256: "SHA256:current",
+    })).toBe(true);
+
+    expect(shouldShowRootUserInfoBanner({
+      username: "root",
+      hostKeyVerificationEnabled: 1,
+      rootUserBannerDismissed: 1,
+      rootUserBannerDismissedHostKeyFingerprintSha256: "SHA256:current",
+      trustedHostKeyFingerprintSha256: "SHA256:current",
+    })).toBe(false);
+
+    expect(shouldShowRootUserInfoBanner({
+      username: "root",
+      hostKeyVerificationEnabled: 1,
+      rootUserBannerDismissed: 1,
+      rootUserBannerDismissedHostKeyFingerprintSha256: "SHA256:old",
+      trustedHostKeyFingerprintSha256: "SHA256:new",
+    })).toBe(true);
+
+    expect(shouldShowRootUserInfoBanner({
+      username: "root",
+      hostKeyVerificationEnabled: 1,
+      rootUserBannerDismissed: 1,
+      rootUserBannerDismissedHostKeyFingerprintSha256: "SHA256:old",
+      trustedHostKeyFingerprintSha256: null,
+    })).toBe(false);
+
+    expect(shouldShowRootUserInfoBanner({
+      username: "root",
+      hostKeyVerificationEnabled: 1,
+      rootUserBannerDismissed: 1,
+      rootUserBannerDismissedHostKeyFingerprintSha256: null,
+      trustedHostKeyFingerprintSha256: null,
+    })).toBe(false);
+
+    expect(shouldShowRootUserInfoBanner({
+      username: "root",
+      hostKeyVerificationEnabled: 1,
+      rootUserBannerDismissed: 1,
+      rootUserBannerDismissedHostKeyFingerprintSha256: "SHA256:old",
+      trustedHostKeyFingerprintSha256: null,
+    })).toBe(false);
+
+    expect(shouldShowRootUserInfoBanner({
+      username: "root",
+      hostKeyVerificationEnabled: 0,
+      rootUserBannerDismissed: 0,
+      rootUserBannerDismissedHostKeyFingerprintSha256: null,
+      trustedHostKeyFingerprintSha256: null,
+    })).toBe(true);
   });
 });
 

--- a/tests/client/system-detail-activity.test.ts
+++ b/tests/client/system-detail-activity.test.ts
@@ -10,6 +10,7 @@ import {
   filterInstalledPackages,
   InstalledPackagesSection,
   getVisiblePackageIssuesForCurrentCheck,
+  HostKeyVerificationBanner,
   isScrollNearBottom,
   matchesHistoryEntryToSession,
   PackageManagerIssueBanner,
@@ -134,6 +135,20 @@ describe("RootUserInfoBanner", () => {
       rootUserBannerDismissedHostKeyFingerprintSha256: null,
       trustedHostKeyFingerprintSha256: null,
     })).toBe(true);
+  });
+});
+
+describe("HostKeyVerificationBanner", () => {
+  test("renders host-key approval guidance with a configuration action", () => {
+    const html = renderToStaticMarkup(createElement(HostKeyVerificationBanner, {
+      systemName: "Debian",
+      onOpenConfiguration: () => {},
+    }));
+
+    expect(html).toContain("SSH host-key approval required");
+    expect(html).toContain("Debian needs its SSH host key reviewed");
+    expect(html).toContain("Open Configuration");
+    expect(html).toContain("bg-red-50");
   });
 });
 

--- a/tests/client/system-detail-activity.test.ts
+++ b/tests/client/system-detail-activity.test.ts
@@ -19,6 +19,8 @@ import {
   toggleSelectedPackageName,
   resolveCurrentActivitySession,
   shouldShowAutoremoveAction,
+  getOperationNoticeState,
+  OperationNoticeBanner,
 } from "../../client/pages/SystemDetail";
 import { SudoersSetupPanel } from "../../client/components/systems/SudoersSetupPanel";
 import type { ActiveOperation, HistoryEntry, PackageManagerIssue } from "../../client/lib/systems";
@@ -149,6 +151,59 @@ describe("HostKeyVerificationBanner", () => {
     expect(html).toContain("Debian needs its SSH host key reviewed");
     expect(html).toContain("Open Configuration");
     expect(html).toContain("bg-red-50");
+  });
+});
+
+describe("OperationNoticeBanner", () => {
+  test("renders generic update-check failures as a page-level banner", () => {
+    const html = renderToStaticMarkup(createElement(OperationNoticeBanner, {
+      state: {
+        kind: "check_failed",
+        title: "Update check failed",
+        message: "The latest update check did not complete, so the package list may be unavailable.",
+        error: "Error: All configured authentication methods failed",
+      },
+    }));
+
+    expect(html).toContain("Update check failed");
+    expect(html).toContain("All configured authentication methods failed");
+    expect(html).toContain("mb-6");
+    expect(html).toContain("bg-red-50");
+    expect(html).not.toContain("mx-4");
+  });
+
+  test("renders failed upgrade activity as the same page-level banner", () => {
+    const state = getOperationNoticeState(createHistoryEntry({
+      id: 3,
+      action: "upgrade_all",
+      pkgManager: "apt",
+      status: "failed",
+      error: "E: Could not get lock /var/lib/dpkg/lock-frontend",
+      startedAt: "2026-05-18 10:00:00",
+      completedAt: "2026-05-18 10:00:02",
+    }), 0);
+    const html = renderToStaticMarkup(createElement(OperationNoticeBanner, { state }));
+
+    expect(state).toMatchObject({
+      kind: "operation_failed",
+      title: "Upgrade failed",
+      error: "E: Could not get lock /var/lib/dpkg/lock-frontend",
+    });
+    expect(html).toContain("Upgrade failed");
+    expect(html).toContain("Could not get lock");
+    expect(html).toContain("mb-6");
+  });
+
+  test("does not produce a banner state for a latest successful operation", () => {
+    expect(getOperationNoticeState(createHistoryEntry({
+      id: 4,
+      action: "reboot",
+      pkgManager: "system",
+      status: "success",
+      error: "older checks may have failed, but this row is current",
+      startedAt: "2026-05-18 11:00:00",
+      completedAt: "2026-05-18 11:00:10",
+    }), 0)).toBeNull();
   });
 });
 

--- a/tests/client/system-status.test.ts
+++ b/tests/client/system-status.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "vitest";
-import { deriveSystemUpdateState, getUpdatesPanelState, shouldClearLocalUpgrade } from "../../client/lib/system-status";
+import {
+  deriveSystemUpdateState,
+  getUpdatesPanelState,
+  hasHostKeyVerificationError,
+  isHostKeyVerificationErrorMessage,
+  omitHostKeyVerificationErrorFromUpdatesPanelState,
+  shouldClearLocalUpgrade,
+} from "../../client/lib/system-status";
 import type { ActiveOperation, LastCheckSummary } from "../../client/lib/systems";
 
 function makeLastCheck(status: LastCheckSummary["status"], error: string | null = null): LastCheckSummary {
@@ -160,5 +167,46 @@ describe("getUpdatesPanelState", () => {
     expect(
       getUpdatesPanelState({ lastCheck: makeLastCheck("success") }, 0),
     ).toEqual({ kind: "up_to_date" });
+  });
+});
+
+describe("host-key update notice handling", () => {
+  test("recognizes host-key verification errors including the misspelled variant", () => {
+    expect(isHostKeyVerificationErrorMessage("HostKeyVerificationError")).toBe(true);
+    expect(isHostKeyVerificationErrorMessage("HostKeyVarificationError")).toBe(true);
+    expect(isHostKeyVerificationErrorMessage("SSH host key approval required")).toBe(true);
+    expect(isHostKeyVerificationErrorMessage("sudo password required")).toBe(false);
+  });
+
+  test("detects host-key failures from the latest check summary", () => {
+    expect(
+      hasHostKeyVerificationError(makeLastCheck("failed", "SSH host key verification failed")),
+    ).toBe(true);
+    expect(hasHostKeyVerificationError(makeLastCheck("failed", "network unreachable"))).toBe(false);
+  });
+
+  test("removes host-key errors from the inline updates panel", () => {
+    expect(
+      omitHostKeyVerificationErrorFromUpdatesPanelState({
+        kind: "check_failed",
+        title: "Update check failed",
+        message: "The latest update check did not complete, so the package list may be unavailable.",
+        error: "HostKeyVerificationError: SSH host key approval required",
+      }),
+    ).toBeNull();
+
+    expect(
+      omitHostKeyVerificationErrorFromUpdatesPanelState({
+        kind: "check_warning",
+        title: "Update check completed with warnings",
+        message: "One or more package manager checks failed, so this result may be incomplete.",
+        error: "[apt] mirror failed\n\nHostKeyVerificationError: SSH host key approval required",
+      }),
+    ).toEqual({
+      kind: "check_warning",
+      title: "Update check completed with warnings",
+      message: "One or more package manager checks failed, so this result may be incomplete.",
+      error: "[apt] mirror failed",
+    });
   });
 });

--- a/tests/client/systems-list.test.tsx
+++ b/tests/client/systems-list.test.tsx
@@ -56,7 +56,7 @@ vi.mock("../../client/components/Layout", () => ({
   ),
 }));
 
-import SystemsList from "../../client/pages/SystemsList";
+import SystemsList, { getEditSystemIdFromRouteState } from "../../client/pages/SystemsList";
 
 describe("SystemsList", () => {
   beforeEach(() => {
@@ -139,5 +139,11 @@ describe("SystemsList", () => {
     expect(html).toContain('title="Sudoers setup"');
     expect(html).toContain('aria-label="Sudoers setup for Alpha"');
     expect(html).not.toContain("Sudoers Setup for Alpha");
+  });
+
+  test("parses the system configuration route state", () => {
+    expect(getEditSystemIdFromRouteState({ editSystemId: 42 })).toBe(42);
+    expect(getEditSystemIdFromRouteState({ editSystemId: "42" })).toBeNull();
+    expect(getEditSystemIdFromRouteState(null)).toBeNull();
   });
 });

--- a/tests/client/systems.test.ts
+++ b/tests/client/systems.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+import { getApprovedHostKeyInvalidationSystemIds } from "../../client/lib/systems";
+
+describe("getApprovedHostKeyInvalidationSystemIds", () => {
+  test("returns unique systems whose host keys were approved", () => {
+    expect(getApprovedHostKeyInvalidationSystemIds([
+      {
+        systemId: 7,
+        role: "target",
+        host: "host-a",
+        port: 22,
+        algorithm: "ssh-ed25519",
+        fingerprintSha256: "SHA256:a",
+        rawKey: "key-a",
+      },
+      {
+        systemId: 7,
+        role: "target",
+        host: "host-a",
+        port: 22,
+        algorithm: "ssh-ed25519",
+        fingerprintSha256: "SHA256:a",
+        rawKey: "key-a",
+      },
+      {
+        systemId: 9,
+        role: "jump",
+        host: "jump",
+        port: 22,
+        algorithm: "ssh-ed25519",
+        fingerprintSha256: "SHA256:b",
+        rawKey: "key-b",
+      },
+      {
+        role: "target",
+        host: "new-host",
+        port: 22,
+        algorithm: "ssh-ed25519",
+        fingerprintSha256: "SHA256:c",
+        rawKey: "key-c",
+      },
+    ])).toEqual([7, 9]);
+  });
+});

--- a/tests/client/terminal-text.test.tsx
+++ b/tests/client/terminal-text.test.tsx
@@ -34,6 +34,7 @@ describe("CopyableCodeBlock", () => {
     );
 
     expect(html).toContain("min-height:2.75rem");
+    expect(html).toContain("z-[1]");
   });
 });
 

--- a/tests/server/db-startup-cleanup.test.ts
+++ b/tests/server/db-startup-cleanup.test.ts
@@ -365,6 +365,17 @@ describe("database startup cleanup", () => {
     expect(columns.some((column) => column.name === "reboot_dismissed_at")).toBe(true);
   });
 
+  test("adds the root user banner dismissal columns for systems", () => {
+    const sqlite = new Database(dbPath, { readonly: true });
+    const columns = sqlite
+      .prepare("PRAGMA table_info(systems)")
+      .all() as Array<{ name?: string }>;
+    sqlite.close();
+
+    expect(columns.some((column) => column.name === "root_user_banner_dismissed")).toBe(true);
+    expect(columns.some((column) => column.name === "root_user_banner_dismissed_host_key_fingerprint_sha256")).toBe(true);
+  });
+
   test("creates package manager issue tracking table", () => {
     const sqlite = new Database(dbPath, { readonly: true });
     const columns = sqlite

--- a/tests/server/sudoers-preview-route.test.ts
+++ b/tests/server/sudoers-preview-route.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { Hono } from "hono";
+import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { closeDatabase, getDb, initDatabase } from "../../server/db";
 import { systems } from "../../server/db/schema";
@@ -24,7 +25,7 @@ describe("sudoers preview route", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  function createSystem(username = "updater") {
+  function createSystem(username = "updater", trustedHostKeyFingerprintSha256: string | null = null) {
     return getDb().insert(systems).values({
       name: "Preview host",
       hostname: "preview.local",
@@ -33,6 +34,7 @@ describe("sudoers preview route", () => {
       username,
       pkgManager: "apt",
       detectedPkgManagers: JSON.stringify(["apt"]),
+      trustedHostKeyFingerprintSha256,
     }).returning({ id: systems.id }).get().id;
   }
 
@@ -108,7 +110,7 @@ describe("sudoers preview route", () => {
   });
 
   test("generates a resolved preview for root users", async () => {
-    const systemId = createSystem("root");
+    const systemId = createSystem("root", "SHA256:current");
     const sshManager = initSSHManager(1, 1, 1, getEncryptor());
     (sshManager as any).connect = vi.fn(async () => ({}));
     (sshManager as any).disconnect = vi.fn();
@@ -132,5 +134,28 @@ describe("sudoers preview route", () => {
     expect(body.required).toBe(true);
     expect(body.content).toContain("Defaults:root !requiretty");
     expect((sshManager as any).connect).toHaveBeenCalledTimes(1);
+  });
+
+  test("dismisses the root user banner for a system", async () => {
+    const systemId = createSystem("root", "SHA256:current");
+    const app = new Hono();
+    app.route("/api/systems", systemsRoutes);
+
+    const response = await app.request(`/api/systems/${systemId}/dismiss-root-user-banner`, {
+      method: "POST",
+    });
+    const row = getDb()
+      .select({
+        rootUserBannerDismissed: systems.rootUserBannerDismissed,
+        rootUserBannerDismissedHostKeyFingerprintSha256:
+          systems.rootUserBannerDismissedHostKeyFingerprintSha256,
+      })
+      .from(systems)
+      .where(eq(systems.id, systemId))
+      .get();
+
+    expect(response.status).toBe(200);
+    expect(row?.rootUserBannerDismissed).toBe(1);
+    expect(row?.rootUserBannerDismissedHostKeyFingerprintSha256).toBe("SHA256:current");
   });
 });

--- a/tests/server/systems-routes.test.ts
+++ b/tests/server/systems-routes.test.ts
@@ -1726,6 +1726,8 @@ describe("systems reorder route", () => {
       trustedHostKeyAlgorithm: "ssh-ed25519",
       trustedHostKeyFingerprintSha256: "SHA256:abc",
       hostKeyTrustedAt: "2026-03-09 10:00:00",
+      rootUserBannerDismissed: 1,
+      rootUserBannerDismissedHostKeyFingerprintSha256: "SHA256:abc",
     }).returning({ id: systems.id }).get().id;
 
     const app = new Hono();
@@ -1741,6 +1743,8 @@ describe("systems reorder route", () => {
     expect(updated?.trustedHostKeyAlgorithm).toBeNull();
     expect(updated?.trustedHostKeyFingerprintSha256).toBeNull();
     expect(updated?.hostKeyTrustedAt).toBeNull();
+    expect(updated?.rootUserBannerDismissed).toBe(0);
+    expect(updated?.rootUserBannerDismissedHostKeyFingerprintSha256).toBeNull();
   });
 
   test("clears stored host key when saving a system with verification disabled", async () => {
@@ -1758,6 +1762,8 @@ describe("systems reorder route", () => {
       trustedHostKeyAlgorithm: "ssh-ed25519",
       trustedHostKeyFingerprintSha256: "SHA256:abc",
       hostKeyTrustedAt: "2026-03-09 10:00:00",
+      rootUserBannerDismissed: 1,
+      rootUserBannerDismissedHostKeyFingerprintSha256: "SHA256:abc",
     }).returning({ id: systems.id }).get().id;
 
     const app = new Hono();
@@ -1781,6 +1787,8 @@ describe("systems reorder route", () => {
     expect(updated?.trustedHostKey).toBeNull();
     expect(updated?.trustedHostKeyAlgorithm).toBeNull();
     expect(updated?.trustedHostKeyFingerprintSha256).toBeNull();
+    expect(updated?.rootUserBannerDismissed).toBe(0);
+    expect(updated?.rootUserBannerDismissedHostKeyFingerprintSha256).toBeNull();
   });
 
   test("allows clearing all disabled package managers on update", async () => {


### PR DESCRIPTION
- Add root-user info banner
- Show host key failures as configuration banner
- Fix dashboard refresh and upgrade actions
- Open host-key configuration inline
- Show operation errors as system detail banners
- Fix command control header layering
- Remove updates column from systems page
- docs: update README API overview
- Style repair and host-key notices as warnings